### PR TITLE
feat: Succinct LLM descriptions + page_facts_count system field

### DIFF
--- a/prompts/entity/entity_researcher.prompty
+++ b/prompts/entity/entity_researcher.prompty
@@ -178,8 +178,8 @@ The schema is provided via the response_format parameter and enforces strict com
 
 **LLM Fields** (suffix `*LLM`):
 - Text arrays containing 1-3 analytical items
-- Each item should be 100-200 words of substantive analysis
-- Focus on actionable insights, not generic descriptions
+- Each item should be 50-100 words of focused analysis
+- State facts directly, no elaboration or background context
 - Always populate with analysis; if speculative, note low confidence
 
 **CIT Fields** (suffix `*CIT`):

--- a/schemas/Research_competitor_schema.yaml
+++ b/schemas/Research_competitor_schema.yaml
@@ -100,15 +100,8 @@ properties:
 - name: competitorAnalysisLLM
   dataType:
   - text
-  description: 'Descriptive analysis of competitive landscape and positioning. Include
-
-    direct competitors identified, alternative solutions, competitive advantages claimed,
-
-    differentiation factors, and competitive threats acknowledged.
-
-    FACTS ONLY - no inline citations or URLs. Put source URLs in competitorAnalysisCIT field.
-
-    '
+  description: |
+    Competitive landscape: direct competitors, alternative solutions, claimed competitive advantages, differentiation factors, and competitive threats.
   tags:
   - LLM
   sets:
@@ -161,15 +154,8 @@ properties:
 - name: marketPositionLLM
   dataType:
   - text
-  description: 'Descriptive analysis of market position and competitive standing. Include
-
-    market leadership claims (leader, challenger, niche player), market share indicators,
-
-    positioning strategy (premium, value, specialist), and competitive moat strength.
-
-    FACTS ONLY - no inline citations or URLs. Put source URLs in marketPositionCIT field.
-
-    '
+  description: |
+    Market position: leadership claims (leader, challenger, niche), market share indicators, positioning strategy (premium, value, specialist), competitive moat strength.
   tags:
   - LLM
   - research
@@ -589,6 +575,17 @@ properties:
   - prompt
   metadata:
     order: 902
+- name: page_facts_count
+  dataType:
+  - int
+  description: Page facts count from Domain at time of research. Used to trigger refresh when more facts become available.
+  moduleConfig:
+    text2vec-weaviate:
+      skip: true
+  sets:
+  - system
+  metadata:
+    order: 903
 - name: citations
   dataType:
   - text[]

--- a/schemas/Research_customer_schema.yaml
+++ b/schemas/Research_customer_schema.yaml
@@ -232,13 +232,8 @@ properties:
 - name: useCaseLLM
   dataType:
   - text[]
-  description: 'Use Case Description - detailed descriptions for each classified use case. Array supports multi-use-case classification
-
-    (ordered by similarity score, [0] is primary).
-
-    FACTS ONLY - no inline citations or URLs. Put source URLs in useCaseCIT field.
-
-    '
+  description: |
+    Use case descriptions: what customers actually do with the product/service, problems solved, workflows enabled.
   tags:
   - LLM
   - score
@@ -555,15 +550,8 @@ properties:
 - name: customerIndustrySegmentLLM
   dataType:
   - text
-  description: 'Primary industry segment description for entity''s customer base (entity-level summary) - rich semantic description
-
-    (50-150 words) of the primary customer segment. Represents the most common or strategically important segment. Source
-
-    for classification to customerIndustrySegmentCat.
-
-    FACTS ONLY - no inline citations or URLs. Put source URLs in customerIndustrySegmentCIT field.
-
-    '
+  description: |
+    Primary customer segment: industry vertical, company profile, and defining characteristics of the entity's main customer base.
   tags:
   - LLM
   - industry
@@ -740,15 +728,8 @@ properties:
 - name: keyCustomerIndustrySegmentLLM
   dataType:
   - text[]
-  description: 'Specific industry segment/vertical for each keyCustomer (parallel to keyCustomers array) - detailed categorization
-
-    within the broader industry for each customer. Array index aligns with keyCustomers array. Source for classification to
-
-    keyCustomerIndustrySegmentCat.
-
-    FACTS ONLY - no inline citations or URLs. Put source URLs in keyCustomerIndustrySegmentCIT field.
-
-    '
+  description: |
+    Industry segment for each key customer (parallel to keyCustomers): specific vertical, niche, or specialization.
   parallel_to: keyCustomers
   moduleConfig:
     text2vec-weaviate:
@@ -906,6 +887,17 @@ properties:
   - timestamp
   metadata:
     order: 909
+- name: page_facts_count
+  dataType:
+  - int
+  description: Page facts count from Domain at time of research. Used to trigger refresh when more facts become available.
+  moduleConfig:
+    text2vec-weaviate:
+      skip: true
+  sets:
+  - system
+  metadata:
+    order: 910
 - name: citations
   dataType:
   - text[]

--- a/schemas/Research_financial_schema.yaml
+++ b/schemas/Research_financial_schema.yaml
@@ -242,13 +242,8 @@ properties:
 - name: growthVelocityLLM
   dataType:
   - text
-  description: 'Descriptive analysis of growth rate and business momentum. Include YoY growth percentages, growth acceleration/deceleration
-
-    trends, expansion metrics, hiring velocity, and growth sustainability indicators.
-
-    FACTS ONLY - no inline citations or URLs. Put source URLs in growthVelocityCIT field.
-
-    '
+  description: |
+    Growth rate and momentum: YoY growth percentages, expansion metrics, hiring velocity, growth trajectory (accelerating, steady, declining).
   tags:
   - LLM
   sets:
@@ -276,13 +271,8 @@ properties:
 - name: profitabilityProfileLLM
   dataType:
   - text
-  description: 'Descriptive analysis of profitability status and path to profitability. Include profit/loss status, EBITDA
-
-    mentions, cash flow indicators, burn rate if applicable, runway estimates, and profitability timeline or achievement.
-
-    FACTS ONLY - no inline citations or URLs. Put source URLs in profitabilityProfileCIT field.
-
-    '
+  description: |
+    Profitability status: profit/loss, EBITDA indicators, burn rate if applicable, cash flow, path to profitability or achievement.
   tags:
   - LLM
   sets:
@@ -310,13 +300,8 @@ properties:
 - name: revenueSizeLLM
   dataType:
   - text
-  description: 'Descriptive analysis of revenue scale and financial size. Include revenue range indicators, ARR/MRR mentions
-
-    if SaaS, revenue growth trajectory, and financial scale relative to industry peers.
-
-    FACTS ONLY - no inline citations or URLs. Put source URLs in revenueSizeCIT field.
-
-    '
+  description: |
+    Revenue scale: revenue range indicators, ARR/MRR if SaaS, revenue growth trajectory, financial scale relative to peers.
   tags:
   - LLM
   sets:
@@ -381,15 +366,8 @@ properties:
 - name: fundingStageLLM
   dataType:
   - text
-  description: 'Describe the entity''s funding history and current stage (100-150 words). Include: funding rounds
-
-    completed (Seed, Series A/B/C, etc.), total capital raised, key investors, latest valuation if
-
-    known, and funding trajectory (bootstrapped, venture-backed, PE-owned, public).
-
-    FACTS ONLY - no inline citations or URLs. Put source URLs in fundingStageCIT field.
-
-    '
+  description: |
+    Funding history: rounds completed (Seed, Series A/B/C), total capital raised, key investors, valuation if known, funding trajectory (bootstrapped, venture-backed, PE-owned, public).
   tags:
   - LLM
   sets:
@@ -782,6 +760,17 @@ properties:
   - review
   metadata:
     order: 910
+- name: page_facts_count
+  dataType:
+  - int
+  description: Page facts count from Domain at time of research. Used to trigger refresh when more facts become available.
+  moduleConfig:
+    text2vec-weaviate:
+      skip: true
+  sets:
+  - system
+  metadata:
+    order: 911
 - name: citations
   dataType:
   - text[]

--- a/schemas/Research_industry_schema.yaml
+++ b/schemas/Research_industry_schema.yaml
@@ -193,10 +193,7 @@ properties:
   dataType:
   - text[]
   description: |
-    Descriptive analysis of business model and revenue generation approach. Include how they make money (B2B SaaS
-    subscriptions, marketplace commissions, professional services), customer acquisition model, and go-to-market strategy
-    fundamentals. Array supports multi-segment classification (ordered by similarity score, [0] is primary).
-    FACTS ONLY - no inline citations or URLs. Put source URLs in businessModelCIT field.
+    How they make money: charging model (subscription, hourly, commission, contingency), who pays (B2B/B2C, enterprise/SMB/consumer), primary revenue stream.
   tags:
   - LLM
   - score
@@ -250,12 +247,7 @@ properties:
   dataType:
   - text[]
   description: |
-    Describe how the entity delivers its products/services to customers (2-3 sentences, ~150 words max). START
-    with the primary delivery mechanism: Does it involve physical hardware or is it software-only? Is infrastructure cloud-hosted,
-    customer-hosted, or shared? How do customers access it (browser, mobile, API, physical device)? Then briefly note deployment
-    approach and key service delivery characteristics. Array supports multi-segment classification (ordered by similarity
-    score, [0] is primary).
-    FACTS ONLY - no inline citations or URLs. Put source URLs in deliveryModelCIT field.
+    How they deliver: software vs hardware, cloud vs on-premise, access method (browser, mobile, API, physical device).
   tags:
   - LLM
   - score
@@ -301,13 +293,7 @@ properties:
   dataType:
   - text[]
   description: |
-    Describe the entity's industry segment positioning (100-150 words). Address these elements: 1. What they
-    do - their primary activity or offering (be specific, not generic) 2. Who they serve - target customers/clients and their
-    characteristics 3. How they operate - their approach or model for delivering value 4. Segment-defining characteristics
-    - what places them in one segment vs adjacent ones. Use specific terminology that would appear in industry publications.
-    Avoid generic terms like "provides solutions" or "offers services." Array supports multi-segment classification (ordered
-    by similarity score, [0] is primary).
-    FACTS ONLY - no inline citations or URLs. Put source URLs in industrySegmentCIT field.
+    Industry position: what they do (specific activity), who they serve (customer type), what distinguishes them from adjacent segments. Use industry terms, not generic phrases.
   tags:
   - LLM
   - score
@@ -525,6 +511,17 @@ properties:
   - prompt
   metadata:
     order: 902
+- name: page_facts_count
+  dataType:
+  - int
+  description: Page facts count from Domain at time of research. Used to trigger refresh when more facts become available.
+  moduleConfig:
+    text2vec-weaviate:
+      skip: true
+  sets:
+  - system
+  metadata:
+    order: 903
 - name: citations
   dataType:
   - text[]

--- a/schemas/Research_journalist_schema.yaml
+++ b/schemas/Research_journalist_schema.yaml
@@ -251,15 +251,8 @@ properties:
 - name: mediaTypeLLM
   dataType:
   - text
-  description: 'Descriptive analysis of types of media coverage and press presence. Include media types found (press releases,
-
-    news articles, podcast interviews, trade publications), newsroom/press page presence, media kit availability, and mix
-
-    of entity-generated vs external coverage.
-
-    FACTS ONLY - no inline citations or URLs. Put source URLs in mediaTypeCIT field.
-
-    '
+  description: |
+    Media types: coverage found (press releases, articles, podcasts, trade publications), newsroom/press page presence, entity-generated vs external coverage mix.
   tags:
   - LLM
   sets:
@@ -286,15 +279,8 @@ properties:
 - name: coverageLevelLLM
   dataType:
   - text
-  description: 'Descriptive analysis of media visibility, coverage breadth, and news momentum. Include coverage volume (article
-
-    count, press release count), media outlet quality (tier-1 vs niche), recency of coverage, coverage trajectory (accelerating,
-
-    steady, declining), and credibility signals from external validation.
-
-    FACTS ONLY - no inline citations or URLs. Put source URLs in coverageLevelCIT field.
-
-    '
+  description: |
+    Coverage level: volume (article/press release count), outlet quality (tier-1 vs niche), recency, coverage trajectory (accelerating, steady, declining).
   tags:
   - LLM
   sets:
@@ -321,15 +307,8 @@ properties:
 - name: mediaSentimentLLM
   dataType:
   - text
-  description: 'Descriptive analysis of sentiment and tone in external media coverage. Include overall sentiment (positive,
-
-    neutral, negative, mixed), media perception (emerging leader, struggling, solid player), how the entity is portrayed externally,
-
-    and tone consistency across different outlets.
-
-    FACTS ONLY - no inline citations or URLs. Put source URLs in mediaSentimentCIT field.
-
-    '
+  description: |
+    Media sentiment: overall tone (positive, neutral, negative, mixed), media perception (emerging leader, solid player), portrayal consistency across outlets.
   tags:
   - LLM
   - research
@@ -566,6 +545,17 @@ properties:
   - prompt
   metadata:
     order: 902
+- name: page_facts_count
+  dataType:
+  - int
+  description: Page facts count from Domain at time of research. Used to trigger refresh when more facts become available.
+  moduleConfig:
+    text2vec-weaviate:
+      skip: true
+  sets:
+  - system
+  metadata:
+    order: 903
 - name: citations
   dataType:
   - text[]
@@ -577,7 +567,7 @@ properties:
   - system
   - prompt
   metadata:
-    order: 902
+    order: 904
 - name: researcher_model_id
   dataType:
   - text

--- a/schemas/Research_leadership_schema.yaml
+++ b/schemas/Research_leadership_schema.yaml
@@ -116,15 +116,8 @@ properties:
 - name: founderProfileLLM
   dataType:
   - text
-  description: 'Describe the founder(s) background and profile (100-150 words). Include: founder names,
-
-    previous company experience, relevant domain expertise, education, founder-led vs
-
-    professional management, and any notable achievements or exits.
-
-    FACTS ONLY - no inline citations or URLs. Put source URLs in founderProfileCIT field.
-
-    '
+  description: |
+    Founder background: names, previous company experience, domain expertise, education, founder-led vs professional management, notable exits.
   tags:
   - LLM
   - research
@@ -284,15 +277,8 @@ properties:
 - name: executiveExperienceLLM
   dataType:
   - text
-  description: 'Describe the executive team''s collective experience (100-150 words). Include: key executives
-
-    and their roles, years of industry experience, previous companies and positions, domain
-
-    expertise depth, and any patterns (e.g., former [BigCo] executives, serial entrepreneurs).
-
-    FACTS ONLY - no inline citations or URLs. Put source URLs in executiveExperienceCIT field.
-
-    '
+  description: |
+    Executive team experience: key executives and roles, years of industry experience, previous companies, domain expertise, patterns (ex-BigCo, serial entrepreneurs).
   tags:
   - LLM
   - research
@@ -435,15 +421,8 @@ properties:
 - name: leadershipStyleLLM
   dataType:
   - text
-  description: 'Describe the leadership and company culture style (100-150 words). Include: management
-
-    approach (hands-on, distributed), decision-making style, company values emphasis,
-
-    growth philosophy (bootstrapped mindset vs hypergrowth), and any visible culture signals.
-
-    FACTS ONLY - no inline citations or URLs. Put source URLs in leadershipStyleCIT field.
-
-    '
+  description: |
+    Leadership style: management approach (hands-on, distributed), decision-making style, company values, growth philosophy (bootstrapped vs hypergrowth), culture signals.
   tags:
   - LLM
   - research
@@ -661,6 +640,17 @@ properties:
   - prompt
   metadata:
     order: 910
+- name: page_facts_count
+  dataType:
+  - int
+  description: Page facts count from Domain at time of research. Used to trigger refresh when more facts become available.
+  moduleConfig:
+    text2vec-weaviate:
+      skip: true
+  sets:
+  - system
+  metadata:
+    order: 911
 - name: citations
   dataType:
   - text[]

--- a/schemas/Research_partner_schema.yaml
+++ b/schemas/Research_partner_schema.yaml
@@ -114,15 +114,8 @@ properties:
 - name: partnerTypeLLM
   dataType:
   - text
-  description: 'Describe the entity''s partnership ecosystem (100-150 words). Include: types of partners
-
-    (technology, channel, integration, strategic), partner program structure, notable partner
-
-    names, and partnership strategy (open ecosystem vs selective partnerships).
-
-    FACTS ONLY - no inline citations or URLs. Put source URLs in partnerTypeCIT field.
-
-    '
+  description: |
+    Partnership ecosystem: types of partners (technology, channel, integration, strategic), partner program structure, notable partners, partnership strategy.
   tags:
   - LLM
   sets:
@@ -239,15 +232,8 @@ properties:
 - name: integrationLLM
   dataType:
   - text
-  description: 'Describe partnership integration depth (100-150 words). Include: how partners integrate
-
-    technically (APIs, native connectors, embedded), co-selling arrangements, joint solutions,
-
-    and integration maturity (marketplace listing vs deep product integration).
-
-    FACTS ONLY - no inline citations or URLs. Put source URLs in integrationCIT field.
-
-    '
+  description: |
+    Partnership integration depth: technical integration (APIs, connectors, embedded), co-selling arrangements, joint solutions, integration maturity.
   tags:
   - LLM
   sets:
@@ -313,15 +299,8 @@ properties:
 - name: revenueImpactLLM
   dataType:
   - text
-  description: 'Describe partnership revenue impact (100-150 words). Include: revenue sharing models,
-
-    referral programs, channel contribution to sales, partner-sourced vs direct revenue
-
-    balance, and any stated partnership revenue metrics.
-
-    FACTS ONLY - no inline citations or URLs. Put source URLs in revenueImpactCIT field.
-
-    '
+  description: |
+    Partnership revenue impact: revenue sharing models, referral programs, channel contribution, partner-sourced vs direct revenue balance.
   tags:
   - LLM
   sets:
@@ -519,6 +498,17 @@ properties:
   - prompt
   metadata:
     order: 902
+- name: page_facts_count
+  dataType:
+  - int
+  description: Page facts count from Domain at time of research. Used to trigger refresh when more facts become available.
+  moduleConfig:
+    text2vec-weaviate:
+      skip: true
+  sets:
+  - system
+  metadata:
+    order: 903
 - name: citations
   dataType:
   - text[]
@@ -530,7 +520,7 @@ properties:
   - system
   - prompt
   metadata:
-    order: 902
+    order: 904
 - name: researcher_model_id
   dataType:
   - text

--- a/schemas/Research_product_schema.yaml
+++ b/schemas/Research_product_schema.yaml
@@ -216,13 +216,8 @@ properties:
 - name: productTypeLLM
   dataType:
   - text[]
-  description: 'Product type description - detailed narrative explaining the product''s nature, capabilities, and how it delivers
-
-    value. Single-element array containing one comprehensive description paragraph.
-
-    FACTS ONLY - no inline citations or URLs. Put source URLs in productTypeCIT field.
-
-    '
+  description: |
+    Product type: what the product is, core capabilities, how it delivers value to customers.
   tags:
   - LLM
   sets:
@@ -334,14 +329,8 @@ properties:
 - name: technologyStackLLM
   dataType:
   - text[]
-  description: 'Technology Stack Description - detailed descriptions for each classified technology stack. Array supports
-    multi-stack
-
-    classification (ordered by similarity score, [0] is primary).
-
-    FACTS ONLY - no inline citations or URLs. Put source URLs in technologyStackCIT field.
-
-    '
+  description: |
+    Technology stack: programming languages, frameworks, infrastructure, cloud platforms, key technical architecture choices.
   tags:
   - LLM
   - score
@@ -393,15 +382,8 @@ properties:
 - name: pricingModelLLM
   dataType:
   - text
-  description: 'Describe the entity''s pricing and revenue model (100-150 words). Include: pricing structure
-
-    (per-seat, usage-based, tiered, enterprise), target customer segments by tier, free trial or
-
-    freemium availability, and any publicly stated pricing. Note if pricing requires contacting sales.
-
-    FACTS ONLY - no inline citations or URLs. Put source URLs in pricingModelCIT field.
-
-    '
+  description: |
+    Pricing model: pricing structure (per-seat, usage-based, tiered), customer segments by tier, free trial/freemium, stated prices or "contact sales."
   tags:
   - LLM
   sets:
@@ -482,17 +464,8 @@ properties:
 - name: integrationProfileLLM
   dataType:
   - text
-  description: 'Describe the entity''s integration capabilities (100-150 words). Include: API availability and
-
-    documentation quality, pre-built integrations and marketplace, webhook support, authentication
-
-    methods (OAuth, API keys), and developer resources. Note integration philosophy (API-first vs
-
-    limited integrations).
-
-    FACTS ONLY - no inline citations or URLs. Put source URLs in integrationProfileCIT field.
-
-    '
+  description: |
+    Integration capabilities: API availability, pre-built integrations, marketplace presence, webhook support, authentication methods, developer resources.
   tags:
   - LLM
   sets:
@@ -683,11 +656,8 @@ properties:
 - name: productMaturityLLM
   dataType:
   - text
-  description: 'Descriptive analysis of product maturity stage and lifecycle position.
-
-    FACTS ONLY - no inline citations or URLs. Put source URLs in productMaturityCIT field.
-
-    '
+  description: |
+    Product maturity: lifecycle stage (MVP, growth, established, mature), market adoption signals, enterprise readiness.
   tags:
   - LLM
   sets:
@@ -764,11 +734,8 @@ properties:
 - name: goToMarketLLM
   dataType:
   - text
-  description: 'Go-to-market strategy analysis including sales motion and customer acquisition approach.
-
-    FACTS ONLY - no inline citations or URLs. Put source URLs in goToMarketCIT field.
-
-    '
+  description: |
+    Go-to-market strategy: sales motion (product-led, sales-led, partner-led), customer acquisition approach, primary distribution channels.
   tags:
   - LLM
   sets:
@@ -968,6 +935,17 @@ properties:
   - prompt
   metadata:
     order: 902
+- name: page_facts_count
+  dataType:
+  - int
+  description: Page facts count from Domain at time of research. Used to trigger refresh when more facts become available.
+  moduleConfig:
+    text2vec-weaviate:
+      skip: true
+  sets:
+  - system
+  metadata:
+    order: 903
 - name: citations
   dataType:
   - text[]
@@ -979,7 +957,7 @@ properties:
   - system
   - prompt
   metadata:
-    order: 902
+    order: 904
 - name: researcher_model_id
   dataType:
   - text

--- a/schemas/Research_risk_schema.yaml
+++ b/schemas/Research_risk_schema.yaml
@@ -130,17 +130,8 @@ properties:
 - name: securityPostureLLM
   dataType:
   - text
-  description: 'Assess security maturity based on visible signals (2-3 sentences, ~100 words max).
-
-    START with overall security maturity:
-
-    - What''s the apparent level of sophistication?
-
-    Then enumerate key visible signals and notable gaps relative to industry standards.
-
-    FACTS ONLY - no inline citations or URLs. Put source URLs in securityPostureCIT field.
-
-    '
+  description: |
+    Security maturity: sophistication level, visible security signals (certifications, practices), notable gaps relative to industry standards.
   tags:
   - LLM
   sets:
@@ -234,17 +225,8 @@ properties:
 - name: complianceCertificationLLM
   dataType:
   - text
-  description: 'Document visible compliance certifications and assess maturity (2-3 sentences, ~100 words max).
-
-    START with overall compliance posture:
-
-    - What''s present vs notably missing for their industry?
-
-    Then list specific certifications (present and gaps) with evidence location.
-
-    FACTS ONLY - no inline citations or URLs. Put source URLs in complianceCertificationCIT field.
-
-    '
+  description: |
+    Compliance posture: certifications present, notable gaps for their industry, compliance maturity level.
   tags:
   - LLM
   sets:
@@ -325,19 +307,8 @@ properties:
 - name: regulatoryEnvironmentLLM
   dataType:
   - text
-  description: 'Assess the regulatory complexity based on industry and markets (2-3 sentences, ~100 words max).
-
-    START with the industry context and regulatory intensity:
-
-    - What industry are they in and how heavily regulated is it?
-
-    - Be specific about the level of oversight
-
-    Then list 3-5 key applicable regulations and their operational impact.
-
-    FACTS ONLY - no inline citations or URLs. Put source URLs in regulatoryEnvironmentCIT field.
-
-    '
+  description: |
+    Regulatory environment: industry regulatory intensity, key applicable regulations, operational impact of compliance requirements.
   tags:
   - LLM
   sets:
@@ -535,6 +506,17 @@ properties:
   - prompt
   metadata:
     order: 902
+- name: page_facts_count
+  dataType:
+  - int
+  description: Page facts count from Domain at time of research. Used to trigger refresh when more facts become available.
+  moduleConfig:
+    text2vec-weaviate:
+      skip: true
+  sets:
+  - system
+  metadata:
+    order: 903
 - name: citations
   dataType:
   - text[]
@@ -546,7 +528,7 @@ properties:
   - system
   - prompt
   metadata:
-    order: 902
+    order: 904
 - name: researcher_model_id
   dataType:
   - text

--- a/schemas/Research_social_schema.yaml
+++ b/schemas/Research_social_schema.yaml
@@ -288,15 +288,8 @@ properties:
 - name: platformPresenceLLM
   dataType:
   - text
-  description: 'Descriptive analysis of social platform coverage and implementation strategy. Include which platforms they''re
-
-    active on (Twitter, LinkedIn, GitHub, Discord, etc.), social auth/sharing implementation, account discovery, engagement
-
-    score, and how platform choices align with their business model and audience.
-
-    FACTS ONLY - no inline citations or URLs. Put source URLs in platformPresenceCIT field.
-
-    '
+  description: |
+    Platform presence: active platforms (Twitter, LinkedIn, GitHub, Discord), social auth/sharing implementation, engagement level, platform-business alignment.
   tags:
   - LLM
   - score
@@ -324,15 +317,8 @@ properties:
 - name: socialContentLLM
   dataType:
   - text
-  description: 'Descriptive analysis of content strategy, messaging themes, and thought leadership positioning. Include content
-
-    themes (product updates, technical education, customer stories), messaging style (promotional, educational, community-focused),
-
-    social proof indicators, and content maturity level.
-
-    FACTS ONLY - no inline citations or URLs. Put source URLs in socialContentCIT field.
-
-    '
+  description: |
+    Content strategy: content themes (product updates, education, customer stories), messaging style (promotional, educational, community-focused), social proof indicators.
   tags:
   - LLM
   - research
@@ -360,17 +346,8 @@ properties:
 - name: communityEngagementLLM
   dataType:
   - text
-  description: 'Describe community engagement and relationship building (2 sentences, ~75 words max).
-
-    START with overall engagement approach:
-
-    - How actively does the entity engage with its community?
-
-    Then list primary channels and note interaction level (two-way vs broadcast-only).
-
-    FACTS ONLY - no inline citations or URLs. Put source URLs in communityEngagementCIT field.
-
-    '
+  description: |
+    Community engagement: engagement approach, primary community channels, interaction level (two-way vs broadcast-only), community building efforts.
   tags:
   - LLM
   sets:
@@ -532,6 +509,17 @@ properties:
   - prompt
   metadata:
     order: 902
+- name: page_facts_count
+  dataType:
+  - int
+  description: Page facts count from Domain at time of research. Used to trigger refresh when more facts become available.
+  moduleConfig:
+    text2vec-weaviate:
+      skip: true
+  sets:
+  - system
+  metadata:
+    order: 903
 - name: citations
   dataType:
   - text[]
@@ -543,7 +531,7 @@ properties:
   - system
   - prompt
   metadata:
-    order: 902
+    order: 904
 - name: researcher_model_id
   dataType:
   - text


### PR DESCRIPTION
## Summary
- Make LLM field descriptions more succinct and extraction-focused
- Add `page_facts_count` system field to all 10 researcher schemas for refresh tracking
- Update system prompt to enforce 50-100 word LLM outputs (was 100-200)

## Changes

### Schema changes (all 10 Research_* schemas)
- **LLM descriptions**: Removed word count directives and citation boilerplate, made extraction-focused
- **New field**: `page_facts_count` (system field) - captures Domain's page_facts_count at time of research

### Prompt changes (entity_researcher.prompty)
- Set LLM output length to 50-100 words (was 100-200)
- Focus on facts, no elaboration

## Use Case
Enables refresh strategy:
```python
if domain.page_facts_count > researcher.page_facts_count:
    # Re-run researcher - more facts available since last research
```

## Dependencies
- Requires [pom-core#735](https://github.com/afctony64/pom-core/issues/735) for `page_facts_count` to be populated during pomflow

## Test Results
- Verified LLM outputs average ~57 words (within 50-100 target)
- Compared old vs new outputs for content quality - no useful information lost