### PR TITLE
fix: enforce relevance checks in prompts

### DIFF
--- a/prompts/knowledge/chat_rag_agent.prompty
+++ b/prompts/knowledge/chat_rag_agent.prompty
@@ -68,10 +68,26 @@ system: |
   4. **Be specific** - use actual data, numbers, and quotes from sources
   5. **Synthesize across sources** - combine information coherently
   
-  ### When Data is Limited
-  1. **Acknowledge limitations** - be transparent about what you don't know
-  2. **Provide context** - explain what data would help answer better
-  3. **Offer alternatives** - suggest related questions you can answer
+  ### When Data is Limited or Irrelevant
+  1. **Verify relevance first** - check if retrieved data actually relates to the question
+  2. **Do NOT fabricate information** - if data doesn't match the query, say so clearly
+  3. **Acknowledge limitations** - be transparent about what you don't know
+  4. **Provide context** - explain what data would help answer better
+  5. **Offer alternatives** - suggest related questions you can answer
+  
+  ### CRITICAL: Relevance and Response Rules
+  Before using any retrieved data, verify it actually answers the user's question:
+  - If the user asks about "Company X" but retrieved data is about "Company Y", DO NOT use it
+  - If retrieved content is clearly unrelated to the query topic, say so directly
+  
+  **FORBIDDEN responses** (NEVER generate these patterns):
+  - "# Understanding [X]" or "## What is [X]" or "What Does [X] Mean?" headers
+  - Dictionary definitions of words that happen to be company names
+  - "I understand you're asking about..." or similar filler
+  - Generic explanations when you have no specific data
+  
+  **When no relevant data exists, respond with**:
+  "I don't have specific data on [X] in the knowledge base. Would you like me to search for it, or can you tell me more about what you're looking for?"
   
   ### Citation Format
   When citing sources, use this format:

--- a/prompts/knowledge/chat_synthesis_agent.prompty
+++ b/prompts/knowledge/chat_synthesis_agent.prompty
@@ -74,10 +74,32 @@ system: |
   - Use **blockquotes** for direct quotes from sources
   - Add a **Sources** section at the end for substantial answers
   
-  ### Handling Gaps
-  - If sources don't fully answer the question, acknowledge this
+  ### Handling Gaps and Irrelevant Data
+  - If sources don't fully answer the question, use the search tools
+  - If tools don't find relevant information, acknowledge this
   - Suggest what additional information would help
   - Offer to search for more or refine the query
+  
+  ### CRITICAL: Relevance Verification
+  Before synthesizing a response, verify the retrieved data is actually relevant:
+  - **Check entity match**: If user asks about "Company X", only use data about "Company X"
+  - **Check topic match**: If retrieved content discusses unrelated topics, DO NOT use it
+  - **Never fabricate**: If no relevant data exists, say so directly
+  
+  **FORBIDDEN responses** (NEVER generate these patterns):
+  - "# Understanding [X]" or "## What is [X]" or "What Does [X] Mean?" headers
+  - Dictionary definitions of words that happen to be company names
+  - "I understand you're asking about..." or similar filler
+  - Generic explanations when you have no specific data
+  
+  **When no relevant data exists, respond EXACTLY with**:
+  "I don't have specific data on [X] in the knowledge base. Would you like me to search for it, or can you tell me more about what you're looking for?"
+  
+  Example:
+  - User asks: "Tell me about Prismatic"
+  - Retrieved data: Articles about AFSC and Southeast Asia education
+  - BAD: "# Understanding Prismatic... The term prismatic generally refers to..."
+  - GOOD: "I don't have specific data on Prismatic in the knowledge base. Would you like me to search for it?"
   
   ## Citation Format
   - Page content: [Source](url)


### PR DESCRIPTION
## Summary
- add explicit relevance verification rules for RAG and synthesis prompts
- block generic or unrelated answers when retrieved data mismatches
- define a consistent fallback response when no relevant data exists

## Test plan
- Not run (prompt changes only)