### PR TITLE
fix: align research citations metadata order

### DIFF
--- a/schemas/Research_competitor_schema.yaml
+++ b/schemas/Research_competitor_schema.yaml
@@ -598,7 +598,7 @@ properties:
   - system
   - prompt
   metadata:
-    order: 902
+    order: 904
 - name: domain
   dataType:
   - text

--- a/schemas/Research_customer_schema.yaml
+++ b/schemas/Research_customer_schema.yaml
@@ -911,7 +911,7 @@ properties:
   - extended
   - prompt
   metadata:
-    order: 902
+    order: 904
 - name: researcher_model_id
   dataType:
   - text

--- a/schemas/Research_financial_schema.yaml
+++ b/schemas/Research_financial_schema.yaml
@@ -782,7 +782,7 @@ properties:
   - system
   - prompt
   metadata:
-    order: 902
+    order: 904
 - name: researcher_model_id
   dataType:
   - text

--- a/schemas/Research_industry_schema.yaml
+++ b/schemas/Research_industry_schema.yaml
@@ -533,7 +533,7 @@ properties:
   - system
   - prompt
   metadata:
-    order: 902
+    order: 904
 - name: processedDate
   dataType:
   - text

--- a/schemas/Research_leadership_schema.yaml
+++ b/schemas/Research_leadership_schema.yaml
@@ -662,7 +662,7 @@ properties:
   - system
   - prompt
   metadata:
-    order: 902
+    order: 904
 - name: researcher_model_id
   dataType:
   - text


### PR DESCRIPTION
## Summary
- align citations metadata order to follow page_facts_count across research schemas

## Test plan
- Not run (schema metadata ordering only)