### PR TITLE
fix: move employeeSizeCat to extended set

### DIFF
--- a/schemas/Research_leadership_schema.yaml
+++ b/schemas/Research_leadership_schema.yaml
@@ -270,7 +270,7 @@ properties:
   - Cat
   - headcount
   sets:
-  - standard
+  - extended
   - EnumCat
   metadata:
     order: 117


### PR DESCRIPTION
Move employeeSizeCat from standard to extended set in Research_leadership_schema.yaml