### PR TITLE
fix: move keyCustomerNAICS and keyCustomerIndustrySegmentLLM to extended

### DIFF
--- a/schemas/Research_customer_schema.yaml
+++ b/schemas/Research_customer_schema.yaml
@@ -676,7 +676,7 @@ properties:
   sets:
   - prompt
   - array
-  - standard
+  - extended
   metadata:
     order: 205
 - name: keyCustomerIndustryCat
@@ -741,7 +741,6 @@ properties:
   sets:
   - prompt
   - array
-  - standard
   - extended
   metadata:
     order: 206


### PR DESCRIPTION
Remove from standard set - these fields should only appear in extended reports