### PR TITLE
fix: shorten display labels in UX configs

### DIFF
--- a/ux_configs/Research_customer_ux.yaml
+++ b/ux_configs/Research_customer_ux.yaml
@@ -11,7 +11,7 @@ fields:
   - nunique
 - name: customerIndustrySegmentCat
   maxWidth: 250
-  label: Customer Industry Segment
+  label: Industry Segment
   aggregations:
   - count
   - nunique
@@ -25,6 +25,21 @@ fields:
   - nunique
 - name: keyCustomers
   label: Key Customers
+  aggregations:
+  - count
+  - nunique
+- name: customerDomain
+  label: Domain
+  aggregations:
+  - count
+  - nunique
+- name: keyCustomerSizeCat
+  label: Size
+  aggregations:
+  - count
+  - nunique
+- name: keyCustomerSectorCat
+  label: Sector
   aggregations:
   - count
   - nunique
@@ -51,17 +66,17 @@ fields:
   - count
   - nunique
 - name: customerIndustry
-  label: Customer Industry
+  label: Industry
   aggregations:
   - count
   - nunique
 - name: keyCustomerNAICS
-  label: Customer Industry NAICS
+  label: NAICS
   aggregations:
   - count
   - nunique
 - name: keyCustomerIndustryCat
-  label: Customer Industry Category
+  label: Industry Category
   aggregations:
   - count
   - nunique

--- a/ux_configs/Research_product_ux.yaml
+++ b/ux_configs/Research_product_ux.yaml
@@ -5,7 +5,7 @@ schema_id: Research_product  # Explicit link to pom-core schema
 fields:
 - name: productTypeCat
   maxWidth: 250
-  label: Product Type
+  label: Type
   aggregations:
   - count
   - nunique
@@ -29,7 +29,7 @@ fields:
   - nunique
 - name: productMaturityCat
   maxWidth: 250
-  label: Product Maturity
+  label: Maturity
   aggregations:
   - count
   - nunique
@@ -38,7 +38,7 @@ fields:
   - count
   - nunique
 - name: productMaturityLLM
-  label: Product Maturity Analysis
+  label: Maturity Analysis
   aggregations:
   - count
   - nunique
@@ -59,12 +59,12 @@ fields:
   - count
   - nunique
 - name: productFeatures
-  label: Product Features
+  label: Features
   aggregations:
   - count
   - nunique
 - name: productDomain
-  label: Product Domain
+  label: Domain
   aggregations:
   - count
   - nunique


### PR DESCRIPTION
## Summary
- Remove redundant "Customer", "Key Customer", and "Product" prefixes from field labels
- Add missing UX config entries for keyCustomerSizeCat, keyCustomerSectorCat, customerDomain
- Shorter column headers in report parallel arrays

## Test plan
- Run entity dossier report and verify column headers are shorter