### PR TITLE
fix(#752): add chunk_total field to Page_facts schema

### DIFF
--- a/schemas/Page_facts_schema.yaml
+++ b/schemas/Page_facts_schema.yaml
@@ -276,6 +276,14 @@ properties:
   moduleConfig:
     text2vec-transformers:
       skip: true
+- name: chunk_total
+  dataType:
+  - int
+  description: Total number of chunks for this page (FIX Issue #752)
+  indexFilterable: true
+  moduleConfig:
+    text2vec-transformers:
+      skip: true
 - name: content_length
   dataType:
   - int


### PR DESCRIPTION
## Summary

Adds `chunk_total` field to Page_facts schema for Issue #752 (content chunking).

## Changes

- Added `chunk_total` (int) field to store total number of chunks per page
- Field is indexFilterable for querying
- Vectorizer skip enabled (not needed for embeddings)

## Related

- pom-core Issue #752: content_chunker exists but is never called
- pom-core v5.8.1 fixes the code side
- This PR fixes the schema side