### PR TITLE
refactor: standardize parallel array enricher schema and prompt

### DIFF
--- a/prompts/default/post_tools/parallel_array_enricher.prompty
+++ b/prompts/default/post_tools/parallel_array_enricher.prompty
@@ -54,12 +54,11 @@ tool_guidance:
       **READ THE FIELD DESCRIPTIONS** - they contain search guidance!
       Examples of what to look for in descriptions:
       - "official website domain" → Search: "{element} {industry} official website"
-      - "LinkedIn profile" → Search: "{element} {role} linkedin profile"
+      - "LinkedIn profile" → Search: "{element} linkedin profile" (+ role if known)
       - "company size" → Search: "{element} employees company size"
       
       **DISAMBIGUATION:**
       - For common names, include: {source_context.title} and {source_context.industry}
-      - For executives: include their role and company name
       - For competitors: include the industry vertical
 
 data_requirements:
@@ -68,11 +67,16 @@ data_requirements:
     # Page facts - broad search without domain filter
     - injector_template: data
       template_vars:
-        collection: Page_facts
-        query: "{{ element }}"
-        alpha: 0.5
+        data_card_id: page_facts_search
+        inject_as: page_facts_response
         limit: 10
-        inject_as: page_facts
+        search_query: "{{ element }}{% if row_context %}{% for _key, value in row_context.items() %} {{ value }}{% endfor %}{% endif %}"
+        search_strategy: hybrid
+        domain: "{{ source_context.domain }}"
+      search:
+        type: hybrid
+        alpha: 0.5
+        query: "{{ element }}{% if row_context %}{% for _key, value in row_context.items() %} {{ value }}{% endfor %}{% endif %}"
   
   error_handling:
     missing_data: "continue"
@@ -85,7 +89,7 @@ outputs:
     description: "Object with field values keyed by field name"
 
 model:
-  api: responses
+  api: chat
   configuration:
     connection: openai_conn
     model: gpt-5-nano
@@ -93,88 +97,46 @@ model:
   parameters:
     response_format:
       type: json_object
-    reasoning_effort: low
     max_retries: 2
 
 ---
 
 system:
-{% if _rendered_system_message %}
-## Researcher Context
-{{ _rendered_system_message[:1500] }}{% if _rendered_system_message|length > 1500 %}
-... (truncated){% endif %}
+You are enriching a single record for **{{ element }}**.
 
----
-{% endif %}
+Context:
+- Tenant: {{ tenant_context.name|default('Unknown') }}
+- Researcher: {{ researcher_context.title|default('Unknown') }}
 
-You are extracting information about **{{ element }}** to fill parallel array fields.
-
-**ENTITY:** {{ source_context.title|default(source_context.domain) }} ({{ source_context.industry|default('technology') }})
-**ARRAY:** {{ anchor_field }} (e.g., keyCompetitors, keyExecutives, keyCustomers)
-{% if row_context %}
-**ROW DATA:** {% for key, value in row_context.items() %}{% if value and value != 'Not disclosed' %}{{ key }}={{ value }}{% if not loop.last %}, {% endif %}{% endif %}{% endfor %}
-{% endif %}
-
-**FIELDS TO FILL (READ THE DESCRIPTIONS - they contain search guidance!):**
+Fields to fill (use descriptions for search guidance):
 {% for field in post_fields %}
-- **{{ field.name }}**: {{ field.description }}
+- {{ field.name }}: {{ field.description }}
 {% endfor %}
 
-**SEARCH STRATEGY:**
-1. Check page_facts first for any existing data
-2. Use brave_search for fields that need web lookup - ALWAYS include company name for disambiguation:
-   - For domains: Search "{{ element }} {{ source_context.industry|default('technology') }} official website"
-   - For LinkedIn: Search "{{ element }} [their role] {{ source_context.title|default(source_context.domain) }} linkedin profile"
-   - For company info: Search "{{ element }} company employees size"
-
-**CRITICAL - DOMAIN FINDING:**
-- Do NOT use LinkedIn, Crunchbase, G2, or profile sites as domains
-- Extract the actual company domain from search results
-- If multiple similar results exist, pick the one that is a competitor/alternative to {{ source_context.title|default(source_context.domain) }}
-- Example: For "CompanyName" in {{ source_context.industry|default('technology') }} context → search "CompanyName {{ source_context.industry|default('technology') }} integration platform official website" to find the right company (not other companies with similar names)
-
-**OUTPUT:** Return JSON with field names as keys. Use null if not found.
-
-{% if researcher_example %}
-## Example Output
-
-For reference, here's an example of expected field values for this researcher type:
-
-```json
-{{ researcher_example | tojson(indent=2) }}
-```
-{% endif %}
+Rules:
+- Use page_facts first when relevant.
+- If web lookup is required, use brave_search.
+- Treat "{{ element }}" as the only company name to search for. Do not search for other competitors.
+- Replace {element} in ENRICHMENT SEARCH templates with "{{ element }}".
+- Return JSON with ONLY the fields listed above. Use null if not found.
 
 user:
 **SUBJECT:** {{ element }}
 
-{% if row_context %}
-**KNOWN DATA:**
-{% for key, value in row_context.items() %}
-{% if value and value != 'Not disclosed' %}
-- {{ key }}: {{ value }}
-{% endif %}
-{% endfor %}
-{% endif %}
-
-{% if page_facts_response is defined and page_facts_response and page_facts_response.results %}
-**PAGE FACTS:**
-{% for fact in page_facts_response.results[:5] %}
-- {{ fact.content|default(fact.properties.content|default(''))|truncate(200) }}
+{% if page_facts_response is defined and page_facts_response %}
+**PAGE FACTS (top 5):**
+{% for fact in page_facts_response[:5] %}
+- {% if fact.content is defined %}{{ fact.content|truncate(200) }}{% elif fact.get is defined %}{{ fact.get('content')|default(fact.get('properties', {}).get('content', ''))|truncate(200) }}{% endif %}
 {% endfor %}
 {% endif %}
 
 **INSTRUCTIONS:**
-1. Review the field descriptions above - they tell you HOW to search
-2. Use brave_search for any fields that need web data:
-   - competitorDomain → search for official website (NOT LinkedIn, G2, Crunchbase)
-   - executiveLinkedIn → search for LinkedIn profile
-   - customerDomain → search for company website
-   - etc.
-3. For domains: ALWAYS search with industry context to find the RIGHT company
-   - Example: "CompanyName" + "{{ source_context.industry|default('technology') }}" + "official website" → finds the correct company domain (not other companies with similar names)
-4. Return JSON with values for: {% for field in post_fields %}{{ field.name }}{% if not loop.last %}, {% endif %}{% endfor %}
+1. Fill the fields for **{{ element }}** only.
+2. Use page_facts if available; otherwise use brave_search.
+3. Follow the field descriptions for search terms and formatting.
+4. Every brave_search query MUST include "{{ element }}" and no other competitor names.
 
+Return JSON with ONLY these exact field names:
 ```json
 {
 {% for field in post_fields %}

--- a/schemas/Research_competitor_schema.yaml
+++ b/schemas/Research_competitor_schema.yaml
@@ -200,23 +200,24 @@ properties:
 - name: competitorAdvantagesVs
   dataType:
   - text[]
-  description: What THIS entity has that this competitor doesn't (parallel to keyCompetitors array) - e.g., "Better technology,
-    simpler setup", "Stronger customer support, faster delivery", "More flexible pricing, easier onboarding". Use "Not disclosed"
-    if advantages unknown. MUST have same length as keyCompetitors array.
+  description: 'What THIS entity has that this competitor doesn''t. ENRICHMENT SEARCH:
+    "{element} vs comparison advantages weaknesses". Examples: "Better technology, simpler setup",
+    "Stronger customer support, faster delivery", "More flexible pricing, easier onboarding".
+    Use "Not disclosed" if advantages unknown. MUST have same length as keyCompetitors array.'
   parallel_to: keyCompetitors
   tags:
   - research
   sets:
   - array
   - standard
-  - prompt
+  - post
   metadata:
     order: 207
   label: Advantages
 - name: competitorDomain
   dataType:
   - text[]
-  description: 'Primary domain for each competitor (parallel to keyCompetitors array). ENRICHMENT SEARCH: "{competitor_name}
+  description: 'Primary domain for each competitor. ENRICHMENT SEARCH: "{element}
     official website domain company". Format: "competitor.com" (no https://, no www). Use "Not disclosed" if cannot find.
     MUST align with keyCompetitors.
 
@@ -235,23 +236,24 @@ properties:
 - name: competitorGapsVs
   dataType:
   - text[]
-  description: What this competitor has that THIS entity doesn't (parallel to keyCompetitors array) - e.g., "More advanced
-    features, larger market presence", "Established brand recognition, broader product line", "Better infrastructure, more
-    resources". Use "Not disclosed" if gaps unknown. MUST have same length as keyCompetitors array.
+  description: 'What this competitor has that THIS entity doesn''t. ENRICHMENT SEARCH:
+    "{element} strengths advantages features". Examples: "More advanced features, larger market presence",
+    "Established brand recognition, broader product line", "Better infrastructure, more resources".
+    Use "Not disclosed" if gaps unknown. MUST have same length as keyCompetitors array.'
   parallel_to: keyCompetitors
   tags:
   - research
   sets:
   - array
   - standard
-  - prompt
+  - post
   metadata:
     order: 206
   label: Gaps
 - name: competitorPositioning
   dataType:
   - text[]
-  description: 'Market positioning for each competitor (parallel to keyCompetitors array). ENRICHMENT SEARCH: "{competitor_name}
+  description: 'Market positioning for each competitor. ENRICHMENT SEARCH: "{element}
     market position leader challenger G2 Gartner". Examples: "Market Leader", "Strong Challenger", "Niche Specialist", "Emerging
     Player". Use "Not disclosed" if unknown. MUST align with keyCompetitors.
 
@@ -269,8 +271,8 @@ properties:
 - name: competitorPriceVs
   dataType:
   - text[]
-  description: 'Price comparison vs THIS entity (parallel to keyCompetitors array). ENRICHMENT SEARCH: "{competitor_name}
-    pricing cost vs {entity_name} comparison". Examples: "$150/user vs our $99", "Premium pricing", "Budget alternative",
+  description: 'Price comparison vs THIS entity. ENRICHMENT SEARCH: "{element}
+    pricing cost vs {element} comparison". Examples: "$150/user vs our $99", "Premium pricing", "Budget alternative",
     "Similar tier". Use "Not disclosed" if unknown. MUST align with keyCompetitors. CLEAN FACTS ONLY.
 
     '
@@ -287,7 +289,7 @@ properties:
 - name: competitorTargetMarket
   dataType:
   - text[]
-  description: 'Target market for each competitor (parallel to keyCompetitors array). ENRICHMENT SEARCH: "{competitor_name}
+  description: 'Target market for each competitor. ENRICHMENT SEARCH: "{element}
     target market customers enterprise SMB". Examples: "Enterprise", "SMB", "Mid-market", "Startups", "Healthcare vertical".
     Use "Not disclosed" if unknown. MUST align with keyCompetitors.
 
@@ -319,7 +321,7 @@ properties:
 - name: keyCompetitorEvidence
   dataType:
   - text[]
-  description: 'Evidence/context found for each keyCompetitor from page facts and web search (parallel to keyCompetitors).
+  description: 'Evidence/context found for each keyCompetitor from page facts and web search.
     Auto-populated during enrichment. Contains source text snippets about competitive positioning, pricing, features mentioned
     for this competitor. MUST align with keyCompetitors.
 

--- a/schemas/Research_customer_schema.yaml
+++ b/schemas/Research_customer_schema.yaml
@@ -133,7 +133,7 @@ properties:
 - name: customerDomain
   dataType:
   - text[]
-  description: 'Primary domain for each key customer (parallel to keyCustomers array). ENRICHMENT SEARCH: "{customer_name}
+  description: 'Primary domain for each key customer. ENRICHMENT SEARCH: "{element}
     official website domain company". Format: "customer.com" (no https://, no www, just the domain). Use "Not disclosed" if
     cannot find. MUST align with keyCustomers array. Used for spawning Domain records.
 
@@ -154,7 +154,7 @@ properties:
 - name: keyCustomerSizeCat
   dataType:
   - text[]
-  description: 'Customer size segment for each keyCustomer (parallel to keyCustomers array). ENRICHMENT SEARCH: "{customer_name}
+  description: 'Customer size segment for each keyCustomer. ENRICHMENT SEARCH: "{element}
     company employees size revenue". Classify as Enterprise (1000+ employees), Mid-Market (100-999), SMB (10-99), Startup
     (<10). Use "Not disclosed" if segment unknown. MUST have same length as keyCustomers array.
 
@@ -183,7 +183,7 @@ properties:
 - name: productUsed
   dataType:
   - text[]
-  description: Product or service each keyCustomer uses (parallel to keyCustomers array) - e.g., "Premium Plan", "Professional
+  description: Product or service each keyCustomer uses - e.g., "Premium Plan", "Professional
     Service", "Complete Package". Use "Not disclosed" if product unknown. MUST have same length as keyCustomers array.
   parallel_to: keyCustomers
   moduleConfig:
@@ -199,7 +199,7 @@ properties:
 - name: primaryUseCase
   dataType:
   - text[]
-  description: Primary use case for each keyCustomer (parallel to keyCustomers array) - e.g., "Core operations", "Business
+  description: Primary use case for each keyCustomer - e.g., "Core operations", "Business
     management", "Service delivery". Use "Not disclosed" if use case unknown. MUST have same length as keyCustomers array.
   parallel_to: keyCustomers
   moduleConfig:
@@ -215,7 +215,7 @@ properties:
 - name: keyCustomerEvidence
   dataType:
   - text[]
-  description: Evidence/context found for each keyCustomer from page facts and web search (parallel to keyCustomers array).
+  description: Evidence/context found for each keyCustomer from page facts and web search.
     Summarize factual basis for classifications and extracted values.
   parallel_to: keyCustomers
   moduleConfig:
@@ -297,7 +297,7 @@ properties:
 - name: caseStudies
   dataType:
   - text[]
-  description: Case study summary for each keyCustomer (parallel to keyCustomers array) - one concise line per customer success
+  description: Case study summary for each keyCustomer - one concise line per customer success
     story with quantifiable results. Use "Not disclosed" if no case study available for a customer. MUST have same length
     as keyCustomers array.
   parallel_to: keyCustomers
@@ -411,7 +411,7 @@ properties:
 - name: useCaseSimilarities
   dataType:
   - number[]
-  description: Similarity scores for each classified use case (parallel to useCaseCat, ordered highest to lowest, [0] is primary)
+  description: Similarity scores for each classified use case (ordered highest to lowest, [0] is primary)
   moduleConfig:
     text2vec-weaviate:
       skip: true
@@ -427,7 +427,7 @@ properties:
 - name: useCaseMatchedSeeds
   dataType:
   - text[]
-  description: Names of seed records matched for each use case (parallel to useCaseCat, [0] is primary)
+  description: Names of seed records matched for each use case ([0] is primary)
   moduleConfig:
     text2vec-weaviate:
       skip: true
@@ -622,7 +622,7 @@ properties:
 - name: keyCustomerSectorCat
   dataType:
   - text[]
-  description: Industry sector for each keyCustomer (parallel to keyCustomers array) - Level 1 top-level industry classification
+  description: Industry sector for each keyCustomer - Level 1 top-level industry classification
     (Software, Healthcare, Financial Services, etc.). Enum values mirror Industry.sector field. Use "Unknown" if sector cannot
     be determined. MUST have same length as keyCustomers array.
   enum:
@@ -662,7 +662,7 @@ properties:
 - name: keyCustomerNAICS
   dataType:
   - text[]
-  description: NAICS description for each keyCustomer (parallel to keyCustomers array) - 6-digit NAICS classification with
+  description: NAICS description for each keyCustomer - 6-digit NAICS classification with
     name (e.g., "Software Publishers (511210)"). Use "Unknown" if NAICS cannot be determined. MUST have same length as keyCustomers
     array.
   parallel_to: keyCustomers
@@ -682,7 +682,7 @@ properties:
 - name: keyCustomerIndustryCat
   dataType:
   - text[]
-  description: Industry category for each keyCustomer (parallel to keyCustomers array) - Level 2 mid-level industry classification
+  description: Industry category for each keyCustomer - Level 2 mid-level industry classification
     within sector (e.g., "Enterprise Applications", "Medical Devices", "Banking & Lending"). Enum values mirror Industry.industry
     field. Use "Unknown" if industry cannot be determined. MUST have same length as keyCustomers array.
   enum:
@@ -729,7 +729,7 @@ properties:
   dataType:
   - text[]
   description: |
-    Industry segment for each key customer (parallel to keyCustomers): specific vertical, niche, or specialization.
+    Industry segment for each key customer: specific vertical, niche, or specialization.
   parallel_to: keyCustomers
   moduleConfig:
     text2vec-weaviate:
@@ -762,7 +762,7 @@ properties:
 - name: keyCustomerIndustrySegmentCat
   dataType:
   - text[]
-  description: Granular industry segment classification for each keyCustomer (parallel to keyCustomers array) - semantic classification
+  description: Granular industry segment classification for each keyCustomer - semantic classification
     using shared industrySegment seed data from Industry research. Provides granular industry understanding across hundreds
     of possible verticals (e.g., "Healthcare - Medical Devices" vs "Healthcare - Telemedicine" vs "Healthcare - Pharma").
     Uses same vector training as industrySegmentCat for consistency. Array supports multi-segment classification (ordered

--- a/schemas/Research_leadership_schema.yaml
+++ b/schemas/Research_leadership_schema.yaml
@@ -336,7 +336,7 @@ properties:
 - name: keyExecutiveEvidence
   dataType:
   - text[]
-  description: Evidence/context found for each keyExecutive from page facts search (parallel to keyExecutives array). Stores
+  description: Evidence/context found for each keyExecutive from page facts search. Stores
     the factual basis for classifications and extracted values.
   parallel_to: keyExecutives
   moduleConfig:
@@ -350,8 +350,8 @@ properties:
 - name: executiveBackgrounds
   dataType:
   - text[]
-  description: 'Executive background and experience (parallel to keyExecutives array). ENRICHMENT SEARCH: "{executive_name}
-    {role} career background education experience". Examples: "MBA Stanford, 15yr SaaS veteran", "Ex-Google engineer, 3 startups",
+  description: 'Executive background and experience. ENRICHMENT SEARCH: "{element}
+    career background education experience". Examples: "MBA Stanford, 15yr SaaS veteran", "Ex-Google engineer, 3 startups",
     "McKinsey alum, serial entrepreneur". Use "Not disclosed" if unknown. MUST align with keyExecutives.
 
     '
@@ -369,7 +369,7 @@ properties:
 - name: executiveRoles
   dataType:
   - text[]
-  description: Role/title for each executive (parallel to keyExecutives array) - e.g., "CEO", "CTO", "VP Engineering", "Head
+  description: Role/title for each executive - e.g., "CEO", "CTO", "VP Engineering", "Head
     of Product". Use "Not disclosed" if role unknown. MUST have same length as keyExecutives array.
   parallel_to: keyExecutives
   tags:
@@ -385,8 +385,8 @@ properties:
 - name: executiveTenure
   dataType:
   - text[]
-  description: 'Tenure/time at entity for each executive (parallel to keyExecutives array). ENRICHMENT SEARCH: "{executive_name}
-    joined {company} tenure years". Examples: "5 years", "Since founding (2019)", "2 years", "6 months". Use "Not disclosed"
+  description: 'Tenure/time at entity for each executive. ENRICHMENT SEARCH: "{element}
+    joined company tenure years". Examples: "5 years", "Since founding (2019)", "2 years", "6 months". Use "Not disclosed"
     if unknown. MUST align with keyExecutives.
 
     '
@@ -404,8 +404,8 @@ properties:
 - name: executiveLinkedIn
   dataType:
   - text[]
-  description: 'LinkedIn profile URL for each executive (parallel to keyExecutives array). ENRICHMENT SEARCH: "{executive_name}
-    {role} {company} linkedin profile". Format: https://www.linkedin.com/in/username/ Use "Not disclosed" if LinkedIn profile
+  description: 'LinkedIn profile URL for each executive. ENRICHMENT SEARCH: "{element}
+    linkedin profile". Format: https://www.linkedin.com/in/username/ Use "Not disclosed" if LinkedIn profile
     unknown. MUST align with keyExecutives.
 
     '

--- a/schemas/Research_partner_schema.yaml
+++ b/schemas/Research_partner_schema.yaml
@@ -169,7 +169,7 @@ properties:
 - name: keyPartnerEvidence
   dataType:
   - text[]
-  description: Evidence/context found for each keyPartner from page facts search (parallel to keyPartners array). Stores the
+  description: Evidence/context found for each keyPartner from page facts search. Stores the
     factual basis for classifications and extracted values.
   parallel_to: keyPartners
   moduleConfig:
@@ -183,7 +183,7 @@ properties:
 - name: partnerTypes
   dataType:
   - text[]
-  description: Type of partnership for each partner (parallel to keyPartners array) - e.g., "Technology Partner", "Strategic
+  description: Type of partnership for each partner - e.g., "Technology Partner", "Strategic
     Alliance", "Distribution Partner", "Integration Partner". Use "Not disclosed" if type unknown. MUST have same length as
     keyPartners array.
   parallel_to: keyPartners
@@ -198,7 +198,7 @@ properties:
 - name: partnerValue
   dataType:
   - text[]
-  description: Strategic value/benefit of each partnership (parallel to keyPartners array) - e.g., "Market access", "Technology
+  description: Strategic value/benefit of each partnership - e.g., "Market access", "Technology
     enhancement", "Revenue growth", "Brand recognition". Use "Not disclosed" if value unknown. MUST have same length as keyPartners
     array.
   parallel_to: keyPartners
@@ -213,7 +213,7 @@ properties:
 - name: partnerDomain
   dataType:
   - text[]
-  description: 'Primary domain for each partner (parallel to keyPartners array). ENRICHMENT SEARCH: "{partner_name} official
+  description: 'Primary domain for each partner. ENRICHMENT SEARCH: "{element} official
     website domain company". Format: "partner.com" (no https://, no www). Use "Not disclosed" if cannot find. MUST align with
     keyPartners. Used for spawning Domain records.'
   parallel_to: keyPartners


### PR DESCRIPTION
## Summary
- Change `competitorAdvantagesVs` and `competitorGapsVs` from `prompt` to `post` sets
- Add `ENRICHMENT SEARCH` templates to new post fields
- Simplify `parallel_array_enricher.prompty` context to show tenant/researcher only
- Remove row_context display (no prompt fields in parallel arrays for competitor)
- Use universal `{element}` placeholder in all ENRICHMENT SEARCH descriptions

## Changes
- `schemas/Research_competitor_schema.yaml` - moved 2 fields from prompt to post
- `schemas/Research_customer_schema.yaml` - updated placeholders
- `schemas/Research_leadership_schema.yaml` - updated placeholders  
- `schemas/Research_partner_schema.yaml` - updated placeholders
- `prompts/default/post_tools/parallel_array_enricher.prompty` - simplified context section

## Test plan
- [ ] Run prompt_preview_cli to verify competitor enricher prompt
- [ ] Test enrichment on prismatic.io competitor researcher