### PR TITLE
feat: use {entity} placeholder for vs comparisons

### DIFF
--- a/prompts/default/post_tools/parallel_array_enricher.prompty
+++ b/prompts/default/post_tools/parallel_array_enricher.prompty
@@ -107,9 +107,11 @@ Context:
 {% if researcher_ai and researcher_ai.researcher_identity %}- Researcher: {{ researcher_ai.researcher_identity.title }} - {{ researcher_ai.researcher_identity.mission }}{% endif %}
 {% if record %}{% set props = record.get('properties') or record %}- Entity: {{ props.get('entityName') or props.get('domain') or 'Unknown' }}{% endif %}
 
+{% set props = record.get('properties') or record if record else {} %}
+{% set entity_name = props.get('entityName') or props.get('domain') or 'Unknown' %}
 Fields to fill:
 {% for field in post_fields %}
-- {{ field.name }}: {{ field.description|replace('{element}', element) }}
+- {{ field.name }}: {{ field.description|replace('{element}', element)|replace('{entity}', entity_name) }}
 {% endfor %}
 
 Rules:

--- a/schemas/Research_competitor_schema.yaml
+++ b/schemas/Research_competitor_schema.yaml
@@ -200,8 +200,8 @@ properties:
 - name: competitorAdvantagesVs
   dataType:
   - text[]
-  description: 'What THIS entity has that this competitor doesn''t. ENRICHMENT SEARCH:
-    "{element} vs comparison advantages weaknesses". Examples: "Better technology, simpler setup",
+  description: 'What {entity} has that {element} doesn''t. ENRICHMENT SEARCH:
+    "{element} vs {entity} comparison advantages". Examples: "Better technology, simpler setup",
     "Stronger customer support, faster delivery", "More flexible pricing, easier onboarding".
     Use "Not disclosed" if advantages unknown. MUST have same length as keyCompetitors array.'
   parallel_to: keyCompetitors
@@ -236,8 +236,8 @@ properties:
 - name: competitorGapsVs
   dataType:
   - text[]
-  description: 'What this competitor has that THIS entity doesn''t. ENRICHMENT SEARCH:
-    "{element} strengths advantages features". Examples: "More advanced features, larger market presence",
+  description: 'What {element} has that {entity} doesn''t. ENRICHMENT SEARCH:
+    "{element} vs {entity} comparison advantages". Examples: "More advanced features, larger market presence",
     "Established brand recognition, broader product line", "Better infrastructure, more resources".
     Use "Not disclosed" if gaps unknown. MUST have same length as keyCompetitors array.'
   parallel_to: keyCompetitors
@@ -271,8 +271,8 @@ properties:
 - name: competitorPriceVs
   dataType:
   - text[]
-  description: 'Price comparison vs THIS entity. ENRICHMENT SEARCH: "{element}
-    pricing cost vs {element} comparison". Examples: "$150/user vs our $99", "Premium pricing", "Budget alternative",
+  description: 'Price comparison {element} vs {entity}. ENRICHMENT SEARCH: "{element}
+    vs {entity} pricing comparison cost". Examples: "$150/user vs our $99", "Premium pricing", "Budget alternative",
     "Similar tier". Use "Not disclosed" if unknown. MUST align with keyCompetitors. CLEAN FACTS ONLY.
 
     '


### PR DESCRIPTION
## Summary
- Update competitor schema to use `{entity}` in vs comparison fields
- `competitorAdvantagesVs`: "What {entity} has that {element} doesn't"
- `competitorGapsVs`: "What {element} has that {entity} doesn't"
- `competitorPriceVs`: "Price comparison {element} vs {entity}"
- Update prompty to replace both `{element}` and `{entity}` placeholders

## Example
For Paragon (element) vs Prismatic (entity):
- ENRICHMENT SEARCH: "Paragon vs Prismatic comparison advantages"