### PR TITLE
refactor: rename {element} to {subject} for clarity

### DIFF
--- a/prompts/default/post_tools/parallel_array_enricher.prompty
+++ b/prompts/default/post_tools/parallel_array_enricher.prompty
@@ -111,7 +111,7 @@ Context:
 {% set entity_name = props.get('entityName') or props.get('domain') or 'Unknown' %}
 Fields to fill:
 {% for field in post_fields %}
-- {{ field.name }}: {{ field.description|replace('{element}', element)|replace('{entity}', entity_name) }}
+- {{ field.name }}: {{ field.description|replace('{subject}', element)|replace('{entity}', entity_name) }}
 {% endfor %}
 
 Rules:

--- a/schemas/Research_competitor_schema.yaml
+++ b/schemas/Research_competitor_schema.yaml
@@ -200,8 +200,8 @@ properties:
 - name: competitorAdvantagesVs
   dataType:
   - text[]
-  description: 'What {entity} has that {element} doesn''t. ENRICHMENT SEARCH:
-    "{element} vs {entity} comparison advantages". Examples: "Better technology, simpler setup",
+  description: 'What {entity} has that {subject} doesn''t. ENRICHMENT SEARCH:
+    "{subject} vs {entity} comparison advantages". Examples: "Better technology, simpler setup",
     "Stronger customer support, faster delivery", "More flexible pricing, easier onboarding".
     Use "Not disclosed" if advantages unknown. MUST have same length as keyCompetitors array.'
   parallel_to: keyCompetitors
@@ -217,7 +217,7 @@ properties:
 - name: competitorDomain
   dataType:
   - text[]
-  description: 'Primary domain for each competitor. ENRICHMENT SEARCH: "{element}
+  description: 'Primary domain for each competitor. ENRICHMENT SEARCH: "{subject}
     official website domain company". Format: "competitor.com" (no https://, no www). Use "Not disclosed" if cannot find.
     MUST align with keyCompetitors.
 
@@ -236,8 +236,8 @@ properties:
 - name: competitorGapsVs
   dataType:
   - text[]
-  description: 'What {element} has that {entity} doesn''t. ENRICHMENT SEARCH:
-    "{element} vs {entity} comparison advantages". Examples: "More advanced features, larger market presence",
+  description: 'What {subject} has that {entity} doesn''t. ENRICHMENT SEARCH:
+    "{subject} vs {entity} comparison advantages". Examples: "More advanced features, larger market presence",
     "Established brand recognition, broader product line", "Better infrastructure, more resources".
     Use "Not disclosed" if gaps unknown. MUST have same length as keyCompetitors array.'
   parallel_to: keyCompetitors
@@ -253,7 +253,7 @@ properties:
 - name: competitorPositioning
   dataType:
   - text[]
-  description: 'Market positioning for each competitor. ENRICHMENT SEARCH: "{element}
+  description: 'Market positioning for each competitor. ENRICHMENT SEARCH: "{subject}
     market position leader challenger G2 Gartner". Examples: "Market Leader", "Strong Challenger", "Niche Specialist", "Emerging
     Player". Use "Not disclosed" if unknown. MUST align with keyCompetitors.
 
@@ -271,7 +271,7 @@ properties:
 - name: competitorPriceVs
   dataType:
   - text[]
-  description: 'Price comparison {element} vs {entity}. ENRICHMENT SEARCH: "{element}
+  description: 'Price comparison {subject} vs {entity}. ENRICHMENT SEARCH: "{subject}
     vs {entity} pricing comparison cost". Examples: "$150/user vs our $99", "Premium pricing", "Budget alternative",
     "Similar tier". Use "Not disclosed" if unknown. MUST align with keyCompetitors. CLEAN FACTS ONLY.
 
@@ -289,7 +289,7 @@ properties:
 - name: competitorTargetMarket
   dataType:
   - text[]
-  description: 'Target market for each competitor. ENRICHMENT SEARCH: "{element}
+  description: 'Target market for each competitor. ENRICHMENT SEARCH: "{subject}
     target market customers enterprise SMB". Examples: "Enterprise", "SMB", "Mid-market", "Startups", "Healthcare vertical".
     Use "Not disclosed" if unknown. MUST align with keyCompetitors.
 

--- a/schemas/Research_customer_schema.yaml
+++ b/schemas/Research_customer_schema.yaml
@@ -133,7 +133,7 @@ properties:
 - name: customerDomain
   dataType:
   - text[]
-  description: 'Primary domain for each key customer. ENRICHMENT SEARCH: "{element}
+  description: 'Primary domain for each key customer. ENRICHMENT SEARCH: "{subject}
     official website domain company". Format: "customer.com" (no https://, no www, just the domain). Use "Not disclosed" if
     cannot find. MUST align with keyCustomers array. Used for spawning Domain records.
 
@@ -154,7 +154,7 @@ properties:
 - name: keyCustomerSizeCat
   dataType:
   - text[]
-  description: 'Customer size segment for each keyCustomer. ENRICHMENT SEARCH: "{element}
+  description: 'Customer size segment for each keyCustomer. ENRICHMENT SEARCH: "{subject}
     company employees size revenue". Classify as Enterprise (1000+ employees), Mid-Market (100-999), SMB (10-99), Startup
     (<10). Use "Not disclosed" if segment unknown. MUST have same length as keyCustomers array.
 

--- a/schemas/Research_leadership_schema.yaml
+++ b/schemas/Research_leadership_schema.yaml
@@ -350,7 +350,7 @@ properties:
 - name: executiveBackgrounds
   dataType:
   - text[]
-  description: 'Executive background and experience. ENRICHMENT SEARCH: "{element}
+  description: 'Executive background and experience. ENRICHMENT SEARCH: "{subject}
     career background education experience". Examples: "MBA Stanford, 15yr SaaS veteran", "Ex-Google engineer, 3 startups",
     "McKinsey alum, serial entrepreneur". Use "Not disclosed" if unknown. MUST align with keyExecutives.
 
@@ -385,7 +385,7 @@ properties:
 - name: executiveTenure
   dataType:
   - text[]
-  description: 'Tenure/time at entity for each executive. ENRICHMENT SEARCH: "{element}
+  description: 'Tenure/time at entity for each executive. ENRICHMENT SEARCH: "{subject}
     joined company tenure years". Examples: "5 years", "Since founding (2019)", "2 years", "6 months". Use "Not disclosed"
     if unknown. MUST align with keyExecutives.
 
@@ -404,7 +404,7 @@ properties:
 - name: executiveLinkedIn
   dataType:
   - text[]
-  description: 'LinkedIn profile URL for each executive. ENRICHMENT SEARCH: "{element}
+  description: 'LinkedIn profile URL for each executive. ENRICHMENT SEARCH: "{subject}
     linkedin profile". Format: https://www.linkedin.com/in/username/ Use "Not disclosed" if LinkedIn profile
     unknown. MUST align with keyExecutives.
 

--- a/schemas/Research_partner_schema.yaml
+++ b/schemas/Research_partner_schema.yaml
@@ -213,7 +213,7 @@ properties:
 - name: partnerDomain
   dataType:
   - text[]
-  description: 'Primary domain for each partner. ENRICHMENT SEARCH: "{element} official
+  description: 'Primary domain for each partner. ENRICHMENT SEARCH: "{subject} official
     website domain company". Format: "partner.com" (no https://, no www). Use "Not disclosed" if cannot find. MUST align with
     keyPartners. Used for spawning Domain records.'
   parallel_to: keyPartners


### PR DESCRIPTION
## Summary
- Rename `{element}` to `{subject}` in all schema ENRICHMENT SEARCH descriptions
- Clearer naming convention:
  - `{subject}` = the item being enriched (e.g., Paragon, John Smith)
  - `{entity}` = the main entity being researched (e.g., Prismatic)
- Updated schemas: competitor, leadership, partner, customer
- Updated parallel_array_enricher.prompty to replace `{subject}`

## Example
"Paragon vs Prismatic comparison" where:
- subject = Paragon (the competitor)
- entity = Prismatic (the company being researched)