### PR TITLE
fix: reduce max_turns and max_calls in parallel_array_enricher (#798)

### DIFF
--- a/prompts/default/post_tools/parallel_array_enricher.prompty
+++ b/prompts/default/post_tools/parallel_array_enricher.prompty
@@ -49,7 +49,8 @@ tools:
 tool_guidance:
   brave_search:
     priority: medium
-    max_calls: 3
+    # Issue #798: Reduce from 3 to 2 to minimize API calls and timeouts
+    max_calls: 2
     when_to_use: |
       **DO NOT use brave_search for domain resolution** - use subject_domain or domain_candidates instead.
 
@@ -118,6 +119,9 @@ model:
     max_completion_tokens: 4000
     timeout: 120
     max_retries: 2
+    # Issue #798: Reduce max_turns from default 5 to 2 for faster enrichment
+    # Domain is pre-resolved via injectors, so LLM only needs 1-2 turns
+    max_turns: 2
 
 ---
 


### PR DESCRIPTION
## Problem

AI operations in `parallel_array_enricher` are taking 300-900 seconds (5-15 minutes) per competitor.

## Evidence

From E2E test run (prismatic.io competitor):
```
ERROR 🚨 VERY SLOW AI OPERATION: 426442ms (7.1 minutes)
ERROR 🚨 VERY SLOW AI OPERATION: 435433ms (7.2 minutes)
```

## Root Cause

- `max_turns` was not set (defaulting to 5)
- `max_calls: 3` per competitor × 5 turns = up to 15 sequential operations
- Brave Search API timing out due to too many concurrent requests

## Fix

- `max_turns: 2` (was default 5) - domain is pre-resolved via injectors, LLM only needs 1-2 turns
- `max_calls: 2` (was 3) - minimize API calls and timeouts

## Expected Impact

- 50-60% reduction in enrichment time
- Fewer Brave Search API failures

## Related

- pom-core #798: Critical AI operations analysis
- pom-core #797: Parallel execution support