### PR TITLE
fix: improve parallel array enricher clarity and search queries

### DIFF
--- a/prompts/default/post_tools/parallel_array_enricher.prompty
+++ b/prompts/default/post_tools/parallel_array_enricher.prompty
@@ -75,7 +75,7 @@ data_requirements:
       template_vars:
         tool: brave_search
         params:
-          query: "{{ subject }} {% if tenant and tenant.description %}{{ tenant.description[:100] }}{% endif %} official website domain"
+          query: "{{ subject }} official website"
           count: 5
         inject_as: domain_candidates
     # Page facts - search using field descriptions
@@ -126,21 +126,19 @@ model:
 ---
 
 system:
-You are enriching a single record for **{{ subject }}**.
-
 {% set props = record.get('properties') or record if record else {} %}
 {% set entity_name = props.get('entityName') or props.get('domain') or 'Unknown' %}
 {% set tenant_name = tenant.name|default(tenant.id) if tenant else 'Unknown' %}
-{% set tenant_industry = (tenant|attr('industry_focus'))|default(props.get('industry') if props else '') %}
+{% set tenant_desc = tenant.description|default('') if tenant else '' %}
+{% set researcher_type = researcher_ai.researcher_type|default('related entity') if researcher_ai else 'related entity' %}
 {# Detect the domain field name dynamically from post_fields (e.g., competitorDomain, customerDomain, partnerDomain) #}
 {% set ns = namespace(domain_field='') %}
 {% for field in post_fields %}{% if 'Domain' in field.name and ns.domain_field == '' %}{% set ns.domain_field = field.name %}{% endif %}{% endfor %}
 {% set domain_field_name = ns.domain_field %}
 
-Context:
-{% if tenant %}- Tenant: {{ tenant.name|default(tenant.id) }}{% if tenant.description %} - {{ tenant.description }}{% endif %}{% endif %}
-{% if researcher_ai and researcher_ai.researcher_identity %}- Researcher: {{ researcher_ai.researcher_identity.title }} - {{ researcher_ai.researcher_identity.mission }}{% endif %}
-- Source Entity: {{ entity_name }}
+You are researching **{{ subject }}** as a {{ researcher_type }} of **{{ entity_name }}** for {{ tenant_name }}{% if tenant_desc %}, {{ tenant_desc }}{% endif %}.
+
+**{{ subject }}** is the subject being classified - fill in attributes about {{ subject }}, not {{ entity_name }}.
 
 **DOMAIN RESOLUTION (3 modes):**
 {% if person_domain is defined and person_domain %}
@@ -157,8 +155,13 @@ Fields to fill:
 {% endfor %}
 
 Disambiguation:
-- Include tenant context ({{ tenant_name }}) and industry when relevant{% if tenant_industry %} ({{ tenant_industry }}){% endif %}
 - For ambiguous names (common company/person names), add context from the anchor field ({{ anchor_field }})
+
+**WELL-KNOWN ENTITIES:**
+For famous companies, cities, government agencies, or institutions - trust your training knowledge.
+- You know "City of Denver" is Government, "Microsoft" is Software, "Harvard" is Education
+- page_facts below may be irrelevant (from wrong domains) - ignore if they don't match {{ subject }}
+- Only use page_facts if they clearly reference {{ subject }} specifically
 
 Rules:
 {% if subject_domain is defined and subject_domain and not (person_domain is defined and person_domain) %}

--- a/researcher_ai/competitor_ai.yaml
+++ b/researcher_ai/competitor_ai.yaml
@@ -140,7 +140,7 @@ parallel_array_enrichment:
     - domain                    # Source entity domain for disambiguation
   # enrich_fields: Auto-detected from schema via sets: [post]
   search_query_template: >
-    {subject} {domain} competitor positioning target market pricing comparison advantages
+    {subject} official website
 
 # Post-execution tools: Run automatically after competitor researcher completes
 # Priority-ordered: lower number runs first

--- a/researcher_ai/customer_ai.yaml
+++ b/researcher_ai/customer_ai.yaml
@@ -123,7 +123,7 @@ parallel_array_enrichment:
   # Domain resolution: "Yoti B2B SaaS customer company official website"
   # Evidence/details: "{subject} {domain} customer case study use case industry segment size evidence"
   search_query_template: >
-    {element} B2B SaaS customer company official website
+    {subject} official website
 
 # Post-execution tools for customer research
 post_execution_tools:

--- a/researcher_ai/partner_ai.yaml
+++ b/researcher_ai/partner_ai.yaml
@@ -112,7 +112,7 @@ parallel_array_enrichment:
     - domain                    # Source entity domain for disambiguation
   # enrich_fields: Auto-detected from schema via sets: [post]
   search_query_template: >
-    {subject} {domain} partner integration type marketplace evidence domain
+    {subject} official website
 
 # Post-execution tools: Run automatically after partner researcher completes
 # Priority-ordered: lower number runs first


### PR DESCRIPTION
## Summary
- Clear objective statement in prompt: "researching {subject} as a {researcher_type} of {entity} for {tenant}"
- Simplified search queries from keyword soup to clean "{subject} official website"
- Added well-known entity guidance - trust LLM training for cities, government agencies, famous companies
- Fixed customer_ai.yaml variable: {element} → {subject}

## Problem
LLM was misclassifying obvious entities like "City of Denver" as "Software" because:
1. Search queries were diluted: "City of Denver embedded iPaaS platform for B2B SaaS companies official website domain"
2. Irrelevant page_facts were injected as context
3. Prompt didn't clearly state what to classify vs what provides context

## Example Improvement
**Before:** `City of Denver embedded iPaaS platform for B2B SaaS companies official website domain`
**After:** `City of Denver official website`

## Files Changed
- `prompts/default/post_tools/parallel_array_enricher.prompty` - Main prompt improvements
- `researcher_ai/customer_ai.yaml` - Fix {element} → {subject}
- `researcher_ai/competitor_ai.yaml` - Simplify search template
- `researcher_ai/partner_ai.yaml` - Simplify search template

## Test plan
- [ ] Run 120water.com customer researcher and verify government customers classified correctly
- [ ] Run prismatic.io competitor researcher and verify competitor domains resolved