### PR TITLE
fix: add sector inference guidance to keyCustomerSectorCat

### DIFF
--- a/schemas/Research_customer_schema.yaml
+++ b/schemas/Research_customer_schema.yaml
@@ -624,7 +624,7 @@ properties:
 - name: keyCustomerSectorCat
   dataType:
   - text[]
-  description: 'Industry sector for {subject} - Level 1 top-level classification (Software, Healthcare, Financial Services, etc.). Use "Not Available" if sector cannot be determined.'
+  description: 'Industry sector for {subject} - Level 1 top-level classification. INFER from keyCustomerIndustryCat: each industry maps to exactly one sector (e.g., Enterprise Applications → Software, Banking & Lending → Financial Services, Medical Devices → Healthcare). Use "Not Available" only if industry is unknown.'
   enum:
   - Software
   - Professional Services


### PR DESCRIPTION
## Summary
- Updated `keyCustomerSectorCat` field description to instruct LLM to infer sector from `keyCustomerIndustryCat`
- Each industry maps to exactly one sector (e.g., Enterprise Applications → Software, Banking & Lending → Financial Services)
- Prevents "Not Available" when industry is already correctly classified

## Test plan
- Re-run customer researcher for 120water.com
- Verify sector is inferred from industry (e.g., Municipal Services & Utilities → Government)

Made with [Cursor](https://cursor.com)