### PR TITLE
fix: add bidirectional inference for sector/industry fields

### DIFF
--- a/schemas/Research_customer_schema.yaml
+++ b/schemas/Research_customer_schema.yaml
@@ -681,7 +681,7 @@ properties:
 - name: keyCustomerIndustryCat
   dataType:
   - text[]
-  description: 'Industry category for {subject} - Level 2 mid-level classification (e.g., "Enterprise Applications", "Medical Devices", "Banking & Lending"). Use "Not Available" if industry cannot be determined.'
+  description: 'Industry category for {subject} - Level 2 mid-level classification. INFER from keyCustomerSectorCat: Government → Public Administration/Municipal Services & Utilities/Public Safety/Courts & Justice; Software → Enterprise Applications/Data & AI/DevOps/etc; Financial Services → Banking/Investment/Insurance/Payments. Use "Not Available" only if sector is unknown.'
   enum:
   - Enterprise Applications
   - Data & AI Platforms


### PR DESCRIPTION
## Summary
- Added inference guidance to `keyCustomerIndustryCat` to infer from `keyCustomerSectorCat`
- Creates bidirectional inference: Sector ↔ Industry
- Government → Public Administration/Municipal Services/Public Safety/Courts & Justice
- Software → Enterprise Applications/Data & AI/DevOps/etc
- Financial Services → Banking/Investment/Insurance/Payments

## Problem
LLM was inconsistently filling sector and industry - sometimes one, sometimes the other, sometimes neither.

## Solution
Bidirectional inference ensures both fields are filled when either is known.

## Test plan
- Re-run 120water.com customer researcher
- Verify both sector and industry are consistently filled

Made with [Cursor](https://cursor.com)