### PR TITLE
fix: add explicit examples for sector/industry classification

### DIFF
--- a/schemas/Research_customer_schema.yaml
+++ b/schemas/Research_customer_schema.yaml
@@ -624,7 +624,7 @@ properties:
 - name: keyCustomerSectorCat
   dataType:
   - text[]
-  description: 'Industry sector for {subject} - Level 1 top-level classification. INFER from keyCustomerIndustryCat: each industry maps to exactly one sector (e.g., Enterprise Applications → Software, Banking & Lending → Financial Services, Medical Devices → Healthcare). Use "Not Available" only if industry is unknown.'
+  description: 'Industry sector for {subject} - Level 1 top-level classification. Government = cities, states, federal agencies, water utilities, public services. Software = tech companies, SaaS. Financial Services = banks, insurers, fintech. Healthcare = hospitals, pharma, medical devices. ALWAYS fill this field based on what {subject} is.'
   enum:
   - Software
   - Professional Services
@@ -681,7 +681,7 @@ properties:
 - name: keyCustomerIndustryCat
   dataType:
   - text[]
-  description: 'Industry category for {subject} - Level 2 mid-level classification. INFER from keyCustomerSectorCat: Government → Public Administration/Municipal Services & Utilities/Public Safety/Courts & Justice; Software → Enterprise Applications/Data & AI/DevOps/etc; Financial Services → Banking/Investment/Insurance/Payments. Use "Not Available" only if sector is unknown.'
+  description: 'Industry category for {subject} - Level 2 mid-level classification. Water utilities/public water = Municipal Services & Utilities. City/state/federal agencies = Public Administration. Police/fire = Public Safety. Courts = Courts & Justice. SaaS/software = Enterprise Applications or Vertical SaaS. ALWAYS fill this field based on what {subject} is.'
   enum:
   - Enterprise Applications
   - Data & AI Platforms


### PR DESCRIPTION
## Summary
Replace inference-based field descriptions with explicit examples that don't depend on other fields being set.

### Changes
- **keyCustomerSectorCat**: Added explicit examples - "Government = cities, states, water utilities, public services"
- **keyCustomerIndustryCat**: Added explicit examples - "Water utilities = Municipal Services & Utilities"
- Added "ALWAYS fill this field" instruction to ensure consistent population

## Problem
Previous approach relied on inferring one field from another, but both fields are filled in the same LLM call, so inference doesn't work.

## Solution
Explicit examples tell the LLM exactly what category each type of entity belongs to.

## Test plan
- Re-run 120water.com customer researcher
- Verify both sector AND industry are consistently filled for water utilities

Made with [Cursor](https://cursor.com)