### PR TITLE
fix: add LLM tag to keyCustomerEvidence for enum classification

### DIFF
--- a/schemas/Research_customer_schema.yaml
+++ b/schemas/Research_customer_schema.yaml
@@ -221,6 +221,7 @@ properties:
   tags:
   - customer
   - research
+  - LLM
   sets:
   - post
   - system


### PR DESCRIPTION
## Summary
Added `LLM` tag to `keyCustomerEvidence` field so it's included as context when the enum classifier classifies parallel array fields like `keyCustomerSectorCat` and `keyCustomerIndustryCat`.

## Root Cause
The enum classifier (per Issue #795) only uses LLM-tagged fields parallel to the same anchor as context. Without the LLM tag, the classifier only saw:
- "Denver Water" (the name)

With this fix, it will also see:
- "Municipal water utility serving Denver metro area" (the evidence)

This provides the context needed to correctly classify as Government/Municipal Services.

## Test plan
- Re-run 120water.com customer researcher with --refresh
- Verify both sector and industry are correctly filled for water utilities

Made with [Cursor](https://cursor.com)