### PR TITLE
fix: improve keyCustomerEvidence description for classification

### DIFF
--- a/schemas/Research_customer_schema.yaml
+++ b/schemas/Research_customer_schema.yaml
@@ -213,7 +213,7 @@ properties:
 - name: keyCustomerEvidence
   dataType:
   - text[]
-  description: Evidence/context snippets for each keyCustomer used to justify classifications and extracted values.
+  description: 'Brief description of {subject} as an organization: what type of entity (city, water utility, company, agency), what industry/sector, what they do. Example: "Denver Water is a municipal water utility serving the Denver metro area" or "Acme Corp is an enterprise software company in fintech". This context is used for industry/sector classification.'
   parallel_to: keyCustomers
   moduleConfig:
     text2vec-weaviate:


### PR DESCRIPTION
## Summary
Updated `keyCustomerEvidence` field description to specify what evidence to collect:
- Entity type (city, water utility, company, agency)
- Industry/sector
- What they do

## Problem
Current evidence was capturing domain resolution notes like "LinkedIn company page..." or "Selected official site..." which doesn't help the enum classifier understand what type of entity the customer is.

## Solution
New description with examples:
- "Denver Water is a municipal water utility serving the Denver metro area"
- "Acme Corp is an enterprise software company in fintech"

This provides the context needed for accurate sector/industry classification.

## Test plan
- Re-run 120water.com customer researcher
- Verify evidence now describes entity type, not just domain resolution
- Verify sector/industry classification improves

Made with [Cursor](https://cursor.com)