### PR TITLE
fix: remove numbered list from enum classifier

### DIFF
--- a/prompts/default/classifiers/enum_field_classifier.prompty
+++ b/prompts/default/classifiers/enum_field_classifier.prompty
@@ -87,7 +87,7 @@ user:
 ## Available Options
 
 {% for option in enum_values %}
-{{ loop.index }}. {{ option }}
+- {{ option }}
 {% endfor %}
 
 ## Your Classification


### PR DESCRIPTION
Changed from numbered list to bullet list. LLM was returning '16' instead of 'Government' because it was confused by the numbered format.

Made with [Cursor](https://cursor.com)