### PR TITLE
fix: include Brave snippet in domain candidates for evidence

### DIFF
--- a/prompts/default/post_tools/parallel_array_enricher.prompty
+++ b/prompts/default/post_tools/parallel_array_enricher.prompty
@@ -187,7 +187,7 @@ user:
 {% if domain_candidates is defined and domain_candidates and domain_candidates.results is defined %}
 **DOMAIN CANDIDATES FOR {{ subject }} (pre-searched - pick the correct one):**
 {% for result in domain_candidates.results[:5] %}
-- {{ result.url }} | {{ result.title }}
+- {{ result.url }} | {{ result.title }}{% if result.description %} | {{ result.description }}{% endif %}
 {% endfor %}
 {% endif %}
 


### PR DESCRIPTION
The Brave search returns description snippets like 'Denver Water is the oldest water utility in Colorado...' - now included so LLM has context for evidence/classification.

Made with [Cursor](https://cursor.com)