### PR TITLE
fix: enum classifier - avoid Not Available when context is clear

### DIFF
--- a/prompts/default/classifiers/enum_field_classifier.prompty
+++ b/prompts/default/classifiers/enum_field_classifier.prompty
@@ -56,10 +56,10 @@ You are a **Classification Specialist**. Your task is to classify a company base
 ## Classification Guidelines
 
 1. **Semantic Matching**: Match the MEANING and CONCEPT, not just keywords. The context may use different words than the option names.
-2. **Best Fit**: Choose the option that BEST REPRESENTS the company's characteristics described in the context, even if it's not a perfect word match.
-3. **Primary Focus**: If multiple options could apply, choose the PRIMARY or MOST ACCURATE one based on the context.
-4. **Exact Value**: Return ONLY the exact option value (e.g., "B2B-SaaS" not "B2B SaaS" or "B2B-SaaS business model").
-5. **Unknown Only**: Use "Unknown" ONLY if the context provides insufficient information to make a reasonable classification.
+2. **Best Fit**: Choose the option that BEST REPRESENTS the entity described in the context, even if wording differs.
+3. **Primary Focus**: If multiple options could apply, choose the PRIMARY or MOST ACCURATE one.
+4. **Exact Value**: Return ONLY the exact option value.
+5. **AVOID Not Available/Unknown**: Only use these if context is truly empty or ambiguous. If the context describes what the entity IS (e.g., "water utility", "municipal government", "software company"), you MUST classify it.
 
 {% if researcher_example %}
 ## Example Output


### PR DESCRIPTION
Added explicit guidance: if context describes the entity (water utility, municipal government, etc), MUST classify it. Only use Not Available/Unknown for truly empty or ambiguous context.

Made with [Cursor](https://cursor.com)