### PR TITLE
feat: add AI diagnostics thresholds to shared-config

### DIFF
--- a/shared-config.env
+++ b/shared-config.env
@@ -385,6 +385,18 @@ POMFLOW_MAX_CONCURRENT=20
 CLI_MAX_CONCURRENT=100
 
 # =============================================================================
+# AI DIAGNOSTICS THRESHOLDS
+# =============================================================================
+
+# Slow AI operation warning threshold (milliseconds)
+# Operations exceeding this log a warning for optimization consideration
+AI_SLOW_OPERATION_THRESHOLD_MS=60000
+
+# Very slow AI operation error threshold (milliseconds)
+# Operations exceeding this log an error requiring investigation
+AI_VERY_SLOW_OPERATION_THRESHOLD_MS=90000
+
+# =============================================================================
 # BRAVE SEARCH CONFIGURATION
 # =============================================================================
 


### PR DESCRIPTION
## Summary
- Add `AI_SLOW_OPERATION_THRESHOLD_MS=60000` (60s warning)
- Add `AI_VERY_SLOW_OPERATION_THRESHOLD_MS=90000` (90s error)

Configures pom-core slow operation detection thresholds to reduce noise from false-positive warnings during competitor research runs.

## Test plan
- [ ] Update pom-config in PomAI
- [ ] Run competitor pomflow and verify reduced warning noise

Made with [Cursor](https://cursor.com)