### PR TITLE
feat(schema): Add 20 enricher metadata fields to Domain schema v9.5

### DIFF
--- a/schemas/domain_schema.yaml
+++ b/schemas/domain_schema.yaml
@@ -1,6 +1,6 @@
 type: core
 class: Domain
-version: 9.4
+version: 9.5
 group: url
 weaviate_instance: cloud
 description: |
@@ -19,6 +19,15 @@ description: |
   2. Enrichers discover: content, social_accounts, sitemaps, etc.
   3. TenantGroup.researchers analyze → Research_* collections
   4. Research records reference back to this Domain
+
+  SCHEMA v9.5 CHANGES:
+  - Added 20 enricher metadata fields that were being dropped by SchemaCoercer:
+    advanced_social_features, attempted_locations, business_model_signals,
+    community_features, contact_data_found, contact_source, enrichers_executed,
+    enrichers_successful, homepage_meta_description, homepage_page_title,
+    is_suitable, missing_headers, security_percentage, security_weighted_percentage,
+    security_weighted_score, social_recommendations, stockSymbol,
+    successful_locations, tenantGroup, timeout_occurred
 
   SCHEMA v9.4 CHANGES:
   - Added page_facts_last_run_status for last Page Facts outcome
@@ -1217,6 +1226,232 @@ properties:
   - status_update
   tags:
   - temporal
+
+# ============================================================================
+# ENRICHER METADATA FIELDS - SYSTEM FIELDS (enricher-managed)
+# ============================================================================
+- name: advanced_social_features
+  dataType:
+  - text
+  description: JSON string of advanced social features detected by social_snapshot enricher
+  sets:
+  - system
+  tags:
+  - social
+  - enricher
+
+- name: attempted_locations
+  dataType:
+  - text[]
+  description: Array of URLs attempted during enrichment
+  sets:
+  - system
+  tags:
+  - enricher
+  - processing
+
+- name: business_model_signals
+  dataType:
+  - text
+  description: Business model indicators detected from robots.txt analysis
+  indexSearchable: true
+  tokenization: word
+  sets:
+  - system
+  tags:
+  - business
+  - enricher
+
+- name: community_features
+  dataType:
+  - text[]
+  description: Array of community features detected by social_snapshot enricher
+  sets:
+  - system
+  tags:
+  - social
+  - enricher
+
+- name: contact_data_found
+  dataType:
+  - boolean
+  description: Whether contact data was found during enrichment
+  indexFilterable: true
+  sets:
+  - system
+  tags:
+  - contact
+  - enricher
+
+- name: contact_source
+  dataType:
+  - text
+  description: Source where contact data was found (e.g., homepage, contact page)
+  indexFilterable: true
+  tokenization: field
+  sets:
+  - system
+  tags:
+  - contact
+  - enricher
+
+- name: enrichers_executed
+  dataType:
+  - int
+  description: Count of enrichers executed for this domain
+  indexFilterable: true
+  sets:
+  - system
+  tags:
+  - enricher
+  - metrics
+
+- name: enrichers_successful
+  dataType:
+  - int
+  description: Count of enrichers that completed successfully
+  indexFilterable: true
+  sets:
+  - system
+  tags:
+  - enricher
+  - metrics
+
+- name: homepage_meta_description
+  dataType:
+  - text
+  description: Meta description extracted from homepage
+  indexSearchable: true
+  tokenization: word
+  sets:
+  - system
+  tags:
+  - homepage
+  - metadata
+
+- name: homepage_page_title
+  dataType:
+  - text
+  description: Page title extracted from homepage
+  indexSearchable: true
+  tokenization: word
+  sets:
+  - system
+  tags:
+  - homepage
+  - metadata
+
+- name: is_suitable
+  dataType:
+  - boolean
+  description: Whether domain is suitable for research (has sufficient content)
+  indexFilterable: true
+  sets:
+  - system
+  tags:
+  - quality
+  - filtering
+
+- name: missing_headers
+  dataType:
+  - text[]
+  description: Array of missing security headers detected
+  sets:
+  - system
+  tags:
+  - security
+  - headers
+
+- name: security_percentage
+  dataType:
+  - number
+  description: Security score as percentage (0-100) from http_security_headers enricher
+  indexFilterable: true
+  sets:
+  - system
+  tags:
+  - security
+  - metrics
+
+- name: security_weighted_percentage
+  dataType:
+  - number
+  description: Weighted security score as percentage (0-100) accounting for header importance
+  indexFilterable: true
+  sets:
+  - system
+  tags:
+  - security
+  - metrics
+
+- name: security_weighted_score
+  dataType:
+  - number
+  description: Weighted security score accounting for header importance
+  indexFilterable: true
+  sets:
+  - system
+  tags:
+  - security
+  - metrics
+
+- name: social_recommendations
+  dataType:
+  - text
+  description: Recommendations from social media analysis enricher
+  indexSearchable: true
+  tokenization: word
+  sets:
+  - system
+  tags:
+  - social
+  - enricher
+
+- name: stockSymbol
+  dataType:
+  - text
+  description: Stock ticker symbol if publicly traded company
+  indexFilterable: true
+  tokenization: field
+  sets:
+  - system
+  - prompt
+  tags:
+  - identity
+  - financial
+
+- name: successful_locations
+  dataType:
+  - text[]
+  description: Array of URLs successfully processed during enrichment
+  sets:
+  - system
+  tags:
+  - enricher
+  - processing
+
+- name: tenantGroup
+  dataType:
+  - text
+  description: Tenant group assignment for this domain (determines which researchers to run)
+  indexFilterable: true
+  tokenization: field
+  sets:
+  - system
+  tags:
+  - configuration
+  - processing
+
+- name: timeout_occurred
+  dataType:
+  - boolean
+  description: Whether a timeout occurred during enrichment
+  indexFilterable: true
+  sets:
+  - system
+  tags:
+  - enricher
+  - errors
 
 # ============================================================================
 # ENRICHER RESULTS (audit trail) - SYSTEM FIELD (pipeline-managed)


### PR DESCRIPTION
## Summary
- Added 20 system fields to Domain schema that were being dropped by SchemaCoercer
- All fields marked as `system` set to prevent LLM modification
- Updated schema version from 9.4 to 9.5

## Fields Added
| Field | Type | Source |
|-------|------|--------|
| advanced_social_features | text | social_snapshot |
| attempted_locations | text[] | enricher tracking |
| business_model_signals | text | robots_txt |
| community_features | text[] | social_snapshot |
| contact_data_found | boolean | enricher tracking |
| contact_source | text | enricher tracking |
| enrichers_executed | int | enricher tracking |
| enrichers_successful | int | enricher tracking |
| homepage_meta_description | text | homepage_parser |
| homepage_page_title | text | homepage_parser |
| is_suitable | boolean | quality check |
| missing_headers | text[] | http_security_headers |
| security_percentage | number | http_security_headers |
| security_weighted_percentage | number | http_security_headers |
| security_weighted_score | number | http_security_headers |
| social_recommendations | text | social_snapshot |
| stockSymbol | text | enricher extraction |
| successful_locations | text[] | enricher tracking |
| tenantGroup | text | configuration |
| timeout_occurred | boolean | enricher tracking |

## Test Plan
- [ ] Verify YAML syntax valid (done)
- [ ] Deploy schema update to Weaviate
- [ ] Run research pipeline and confirm no SchemaCoercer warnings

Made with [Cursor](https://cursor.com)