### PR TITLE
fix(profiles): Update REDIS_URL to spark-redis for home mode

### DIFF
--- a/profiles/home.env
+++ b/profiles/home.env
@@ -64,4 +64,9 @@ MAC_TRANSFORMERS_URL=http://host.docker.internal:8093
 # OTHER SERVICES
 # =============================================================================
 
-REDIS_URL=redis://mac-redis:6379
+# Redis URL - Use spark-redis when running containers on Spark server
+# Mac containers use mac-redis, Spark containers use spark-redis
+MAC_REDIS_URL=redis://mac-redis:6379
+SPARK_REDIS_URL=redis://spark-redis:6379
+# Default: spark-redis (most CLI work happens on Spark)
+REDIS_URL=redis://spark-redis:6379


### PR DESCRIPTION
## Summary

When running CLI containers on Spark server, Redis should connect to `spark-redis:6379` not `mac-redis:6379`.

## Changes

- Added `MAC_REDIS_URL=redis://mac-redis:6379` for Mac containers
- Added `SPARK_REDIS_URL=redis://spark-redis:6379` for Spark containers  
- Changed default `REDIS_URL` to `spark-redis` since most CLI work happens on Spark

## Impact

Fixes observability/RunManager not working in `pomai-backend-spark` container because it couldn't connect to Redis at `localhost:6379`.

## Test Plan

- [x] Verified `spark-redis:6379` is accessible from Spark containers
- [x] RunManager can store run data in Redis with correct URL

Made with [Cursor](https://cursor.com)