### PR TITLE
fix: Restore 20 enricher metadata fields to Domain schema

### DIFF
--- a/schemas/domain_schema.yaml
+++ b/schemas/domain_schema.yaml
@@ -1296,6 +1296,233 @@ properties:
   - temporal
 
 # ============================================================================
+# ENRICHER METADATA FIELDS - SYSTEM FIELDS (enricher-managed)
+# These fields were being dropped by SchemaCoercer - added in v9.5
+# ============================================================================
+- name: advanced_social_features
+  dataType:
+  - text
+  description: JSON string of advanced social features detected by social_snapshot enricher
+  sets:
+  - system
+  tags:
+  - social
+  - enricher
+
+- name: attempted_locations
+  dataType:
+  - text[]
+  description: Array of URLs attempted during enrichment
+  sets:
+  - system
+  tags:
+  - enricher
+  - processing
+
+- name: business_model_signals
+  dataType:
+  - text
+  description: Business model indicators detected from robots.txt analysis
+  indexSearchable: true
+  tokenization: word
+  sets:
+  - system
+  tags:
+  - business
+  - enricher
+
+- name: community_features
+  dataType:
+  - text[]
+  description: Array of community features detected by social_snapshot enricher
+  sets:
+  - system
+  tags:
+  - social
+  - enricher
+
+- name: contact_data_found
+  dataType:
+  - boolean
+  description: Whether contact data was found during enrichment
+  indexFilterable: true
+  sets:
+  - system
+  tags:
+  - contact
+  - enricher
+
+- name: contact_source
+  dataType:
+  - text
+  description: Source where contact data was found (e.g., homepage, contact page)
+  indexFilterable: true
+  tokenization: field
+  sets:
+  - system
+  tags:
+  - contact
+  - enricher
+
+- name: enrichers_executed
+  dataType:
+  - int
+  description: Count of enrichers executed for this domain
+  indexFilterable: true
+  sets:
+  - system
+  tags:
+  - enricher
+  - metrics
+
+- name: enrichers_successful
+  dataType:
+  - int
+  description: Count of enrichers that completed successfully
+  indexFilterable: true
+  sets:
+  - system
+  tags:
+  - enricher
+  - metrics
+
+- name: homepage_meta_description
+  dataType:
+  - text
+  description: Meta description extracted from homepage
+  indexSearchable: true
+  tokenization: word
+  sets:
+  - system
+  tags:
+  - homepage
+  - metadata
+
+- name: homepage_page_title
+  dataType:
+  - text
+  description: Page title extracted from homepage
+  indexSearchable: true
+  tokenization: word
+  sets:
+  - system
+  tags:
+  - homepage
+  - metadata
+
+- name: is_suitable
+  dataType:
+  - boolean
+  description: Whether domain is suitable for research (has sufficient content)
+  indexFilterable: true
+  sets:
+  - system
+  tags:
+  - quality
+  - filtering
+
+- name: missing_headers
+  dataType:
+  - text[]
+  description: Array of missing security headers detected
+  sets:
+  - system
+  tags:
+  - security
+  - headers
+
+- name: security_percentage
+  dataType:
+  - number
+  description: Security score as percentage (0-100) from http_security_headers enricher
+  indexFilterable: true
+  sets:
+  - system
+  tags:
+  - security
+  - metrics
+
+- name: security_weighted_percentage
+  dataType:
+  - number
+  description: Weighted security score as percentage (0-100) accounting for header importance
+  indexFilterable: true
+  sets:
+  - system
+  tags:
+  - security
+  - metrics
+
+- name: security_weighted_score
+  dataType:
+  - number
+  description: Weighted security score accounting for header importance
+  indexFilterable: true
+  sets:
+  - system
+  tags:
+  - security
+  - metrics
+
+- name: social_recommendations
+  dataType:
+  - text
+  description: Recommendations from social media analysis enricher
+  indexSearchable: true
+  tokenization: word
+  sets:
+  - system
+  tags:
+  - social
+  - enricher
+
+- name: stockSymbol
+  dataType:
+  - text
+  description: Stock ticker symbol if publicly traded company
+  indexFilterable: true
+  tokenization: field
+  sets:
+  - system
+  - prompt
+  tags:
+  - identity
+  - financial
+
+- name: successful_locations
+  dataType:
+  - text[]
+  description: Array of URLs successfully processed during enrichment
+  sets:
+  - system
+  tags:
+  - enricher
+  - processing
+
+- name: tenantGroup
+  dataType:
+  - text
+  description: Tenant group assignment for this domain (determines which researchers to run)
+  indexFilterable: true
+  tokenization: field
+  sets:
+  - system
+  tags:
+  - configuration
+  - processing
+
+- name: timeout_occurred
+  dataType:
+  - boolean
+  description: Whether a timeout occurred during enrichment
+  indexFilterable: true
+  sets:
+  - system
+  tags:
+  - enricher
+  - errors
+
+# ============================================================================
 # ENRICHER RESULTS (audit trail) - SYSTEM FIELD (pipeline-managed)
 # ============================================================================
 - name: enricherResults


### PR DESCRIPTION
## Summary

- Restores 20 enricher metadata fields to Domain schema that were accidentally removed in PR #69
- These fields are required for enricher status tracking and frontend display

## Files Changed

| File | Change Type | Reason |
|------|-------------|--------|
| schemas/domain_schema.yaml | Addition | Restore fields removed by PR #69 squash merge |

## Deletions Checklist

N/A - This PR only adds fields.

## Root Cause Analysis

PR #68 added 20 enricher metadata fields (advanced_social_features, enrichers_executed, etc.).
PR #69 was intended to only add reasoning_summary to gpt-5-mini.yaml, but was based on a
stale branch that predated PR #68. When PR #69 was squash-merged, it inadvertently reverted
the schema changes from PR #68.

**Lesson**: Always rebase before merging to avoid reverting recent work.

## Testing

- [x] Verified fields exist after merge
- [x] Confirmed SchemaCoercer warnings resolved

## Ownership Verification

Files owned by: pom-core (schemas/)

---
*Reference: Fixes regression from PR #69 reverting PR #68*