### PR TITLE
chore: Add PR template and CODEOWNERS for regression prevention

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,43 @@
+# CODEOWNERS for pom-config
+# See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+#
+# Each line is a file pattern followed by owner(s)
+# Owners are notified and required to approve PRs touching these files
+
+# ============================================================================
+# DEFAULT - All changes require review
+# ============================================================================
+* @afctony64
+
+# ============================================================================
+# CRITICAL PATHS - Schema and model changes require explicit approval
+# These files directly affect database structure and AI behavior
+# ============================================================================
+
+# Schemas define database structure - deletions can break data integrity
+/schemas/ @afctony64
+
+# LLM models affect all AI processing - changes cascade across all apps
+/llm_models/ @afctony64
+
+# Shared environment affects all deployments
+shared-config.env @afctony64
+
+# ============================================================================
+# OWNERSHIP BY AGENT (matches OWNERSHIP.yaml)
+# ============================================================================
+
+# PomAI owns
+/prompts/ @afctony64
+/researcher_ai/ @afctony64
+/data_cards/ @afctony64
+
+# pom-core owns
+/tools/ @afctony64
+
+# PomSpark owns
+/profiles/ @afctony64
+/tenant-routing/ @afctony64
+
+# Pomothy owns
+/ux_configs/ @afctony64

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,38 @@
+## Summary
+<!-- 1-3 bullet points explaining what this PR does -->
+
+-
+
+## Files Changed
+<!-- List the files modified and briefly explain why -->
+
+| File | Change Type | Reason |
+|------|-------------|--------|
+| | | |
+
+## Deletions Checklist
+<!-- REQUIRED if this PR deletes more than 10 lines -->
+<!-- Delete this section if no significant deletions -->
+
+- [ ] Deleted code was duplicate/unused (not accidentally reverting previous work)
+- [ ] Verified against recent PRs that these deletions don't undo prior work
+- [ ] Removal discussed with owner (check OWNERSHIP.yaml for file ownership)
+- [ ] No breaking changes to consumers
+
+**If deleting schema fields**: Explain why these fields are no longer needed:
+<!-- e.g., "Removing deprecated field X that was replaced by field Y in PR #50" -->
+
+## Testing
+<!-- How was this tested? -->
+
+- [ ] Ran locally
+- [ ] Verified in dev environment
+- [ ] N/A (documentation only)
+
+## Ownership Verification
+<!-- Check OWNERSHIP.yaml - which agent/team owns these files? -->
+
+Files owned by: <!-- e.g., PomAI, pom-core, PomSpark, Pomothy -->
+
+---
+*Tip: Run `git diff main --stat` before opening PR to check for unexpected file changes*


### PR DESCRIPTION
## Summary

- Adds PR template with deletions checklist to catch inadvertent reversions
- Adds CODEOWNERS for required reviews on critical paths (schemas, llm_models)

## Files Changed

| File | Change Type | Reason |
|------|-------------|--------|
| .github/PULL_REQUEST_TEMPLATE.md | Addition | Standardize PR descriptions, require deletion justification |
| .github/CODEOWNERS | Addition | Enforce review requirements for critical files |

## Deletions Checklist

N/A - This PR only adds files.

## Background

PR #69 accidentally reverted 20 schema fields from PR #68 due to a stale branch being
squash-merged. These protections help prevent similar regressions by:

1. **PR Template**: Forces authors to list files changed and justify deletions
2. **CODEOWNERS**: Requires owner approval for changes to schemas/ and llm_models/

## Testing

- [x] Verified template renders correctly in GitHub
- [x] Verified CODEOWNERS syntax

## Ownership Verification

Files owned by: Repository infrastructure (all teams benefit)

Made with [Cursor](https://cursor.com)