### PR TITLE
feat: Update OOO mode for Mac + Cloud (intentional-deletion)

### DIFF
--- a/profiles/ooo.env
+++ b/profiles/ooo.env
@@ -2,13 +2,18 @@
 # OOO (OUT OF OFFICE) MODE PROFILE
 # =============================================================================
 #
-# Use when: Running unattended on Spark server (overnight jobs, maintenance)
+# Use when: Away from desk, background processing, Spark offline but internet available
 #
-# This profile configures the ecosystem to run entirely on Spark:
-#   - Spark Ollama (CUDA GPU)
-#   - Spark Transformers (GPU cluster)
-#   - Spark Weaviate
-#   - No Mac dependencies
+# DIFFERENCE FROM TRAVEL MODE:
+#   - OOO: Mac + Cloud Weaviate (internet required)
+#   - Travel: Mac only, fully offline capable
+#
+# This profile configures:
+#   - Mac native Ollama (Metal GPU)
+#   - Mac native Transformers (Metal)
+#   - Mac Weaviate (local collections)
+#   - Cloud Weaviate ENABLED (for cloud tenants/collections)
+#   - No Spark dependencies (Spark offline)
 #
 # To activate: Copy values to shared-config.env or source this file
 #
@@ -21,69 +26,74 @@ POMSPARK_MODE=ooo
 # WEAVIATE CONFIGURATION
 # =============================================================================
 
-# Primary Weaviate mode (Spark local)
-WEAVIATE_MODE=spark
+# Primary Weaviate mode (Mac local - Spark offline)
+WEAVIATE_MODE=local
 
-# Weaviate URLs (Spark only)
-# OOO mode runs on Spark, so containers CAN use spark-weaviate Docker hostname
-# But using spark-65d6.local works from anywhere and is more consistent
-WEAVIATE_URL=http://spark-65d6.local:8080
-SPARK_WEAVIATE_URL=http://spark-65d6.local:8080
-WEAVIATE_GRPC_URL=spark-65d6.local:50051
+# Mac Weaviate (local)
+MAC_WEAVIATE_URL=http://mac-weaviate:8080
+WEAVIATE_URL=http://mac-weaviate:8080
 
-# Mac not available in OOO mode
-# MAC_WEAVIATE_URL=http://mac-weaviate:8080  # Not available
+# Weaviate Cloud (available - internet access)
+WEAVIATE_CLOUD_ENABLED=true
+# WEAVIATE_CLOUD_URL inherited from shared-config.env
+# WEAVIATE_CLOUD_KEY from secrets.env
 
-# Default target
-DEFAULT_WEAVIATE_TARGET=spark
+# Spark offline
+# SPARK_WEAVIATE_URL=http://spark-65d6.local:8080  # Spark offline
+# WEAVIATE_GRPC_URL=spark-65d6.local:50051  # Spark offline
+
+# Default target: Cloud (Spark offline, but Cloud available)
+DEFAULT_WEAVIATE_TARGET=cloud
 
 # =============================================================================
 # OLLAMA CONFIGURATION (LLM Inference)
 # =============================================================================
 
-# Primary Ollama URL (Spark Docker - CUDA GPU)
-OLLAMA_URL=http://spark-ollama:11434
-SPARK_OLLAMA_URL=http://spark-ollama:11434
+# Primary Ollama URL (Mac native - Metal GPU)
+# Docker containers access via host.docker.internal
+OLLAMA_URL=http://host.docker.internal:11435
+MAC_OLLAMA_URL=http://host.docker.internal:11435
 
-# Mac not available in OOO mode
-# MAC_OLLAMA_URL=http://host.docker.internal:11435  # Not available
+# Spark offline
+# SPARK_OLLAMA_URL=http://spark-ollama:11434  # Spark offline
 
 # =============================================================================
 # TRANSFORMERS CONFIGURATION (Embeddings)
 # =============================================================================
 
-# Primary Transformers URL (Spark load balancer - GPU cluster)
-TRANSFORMERS_URL=http://spark-transformers-lb:80
-SPARK_TRANSFORMERS_URL=http://spark-transformers-lb:80
+# Primary Transformers URL (Mac native - Metal)
+TRANSFORMERS_URL=http://host.docker.internal:8093
+MAC_TRANSFORMERS_URL=http://host.docker.internal:8093
 
-# Mac not available in OOO mode
-# MAC_TRANSFORMERS_URL=http://host.docker.internal:8093  # Not available
+# Spark offline
+# SPARK_TRANSFORMERS_URL=http://spark-transformers-lb:80  # Spark offline
 
 # =============================================================================
 # OTHER SERVICES
 # =============================================================================
 
-# Redis on Spark (if available) or use Spark's own Redis
-REDIS_URL=redis://spark-redis:6379
+# Redis on Mac (Spark offline)
+REDIS_URL=redis://mac-redis:6379
 
 # =============================================================================
 # OOO MODE NOTES
 # =============================================================================
 #
 # OOO mode is designed for:
-#   - Overnight batch processing
-#   - Unattended data enrichment
-#   - Background research jobs
+#   - Background processing while away
+#   - Spark offline but internet available
+#   - Cloud Weaviate for persistent data
+#   - Mac for compute (LLM, embeddings)
 #
-# All services run on Spark - no Mac required.
+# OOO vs Travel:
+#   - OOO:    Mac + Cloud (requires internet)
+#   - Travel: Mac only (fully offline)
 #
-# Monitoring:
-#   - Check Grafana: http://spark-65d6.local:3000
-#   - Check Prometheus: http://spark-65d6.local:9090
+# Start native services before Docker:
+#   ./scripts/mac-ollama-metal.sh start
+#   ./scripts/mac-transformers-metal.sh start
 #
-# Start OOO mode:
-#   ssh spark-65d6.local
-#   cd ~/Projects/PomSpark
-#   ./scripts/dev.sh ooo
+# When Spark is back online:
+#   Switch to HOME mode: ./scripts/dev.sh home
 #
 # =============================================================================

--- a/tenant-routing/ooo.yaml
+++ b/tenant-routing/ooo.yaml
@@ -1,52 +1,47 @@
 # =============================================================================
 # OOO (OUT OF OFFICE) MODE TENANT ROUTING
 # =============================================================================
-# Mode: Full remote access via Cloudflare tunnels
-# Use case: Remote development, unattended Spark operations
+# Mode: Mac + Cloud (Spark offline)
+# Use case: Background processing while away, Spark unavailable
 # =============================================================================
 
 mode: ooo
-version: "1.1"
-description: "OOO mode - Full remote access via Cloudflare tunnels"
+version: "1.2"
+description: "OOO mode - Mac compute + Cloud Weaviate (Spark offline)"
 
 defaults:
-  weaviate_target: spark
+  weaviate_target: cloud
   cloud_enabled: true
-  spark_enabled: true
-
-tunnel_config:
-  spark_cloudflare_tunnel:
-    name: spark-services
-    id: "${CLOUDFLARE_TUNNEL_SPARK_ID}"
-    services:
-      ollama: "${SPARK_OLLAMA_TUNNEL_URL}"
-      weaviate: "${SPARK_WEAVIATE_TUNNEL_URL}"
-      transformers: "${SPARK_TRANSFORMERS_TUNNEL_URL}"
+  spark_enabled: false  # Spark is offline
 
 weaviate_instances:
-  spark:
-    url: "${SPARK_WEAVIATE_TUNNEL_URL}"
-    description: "Spark Weaviate via Cloudflare tunnel"
-
   cloud:
     url: "${WEAVIATE_CLOUD_URL}"
     api_key_env: WEAVIATE_CLOUD_KEY
-    description: "Cloud Weaviate - Production data"
+    description: "Cloud Weaviate - Production data (70k+ prismatic objects)"
 
   mac:
     url: "http://mac-weaviate:8080"
     description: "Mac Weaviate - Local development/testing"
 
+  # Spark offline - not available
+  # spark:
+  #   url: "http://spark-65d6.local:8080"
+  #   description: "Spark Weaviate - OFFLINE"
+
 tenants:
   prismatic:
     weaviate_target: cloud
-    description: "Production tenant - routes to Cloud Weaviate"
+    description: "Production tenant - Cloud for research, Mac for pages"
     collections:
+      # Research collections on Cloud (40k+ total)
       Research_*: cloud
-      Opportunity: cloud
-      # OOO mode uses Mac for page processing (safer than tunneling large data)
-      Domain: mac
-      Page_facts: mac
+      Opportunity: cloud      # 1,553 objects
+      Domain: cloud           # 29,226 objects (source of truth)
+      # Page processing on Mac (937k+ objects - main data store)
+      Page_facts: mac         # 937,444 objects
+      Page_content: mac       # 84,414 objects
+      Page_researcher: mac    # 0 objects
       Page_intelligence: cloud
 
   test_db:
@@ -57,12 +52,13 @@ tenants:
     weaviate_target: mac
     description: "Demo tenant - local only"
 
-architecture:
-  spark_access: "Apps → ${SPARK_OLLAMA_TUNNEL_URL} → Cloudflare → Spark (Ollama, Weaviate, Transformers)"
-  security: "All access via Cloudflare Zero Trust, no direct port exposure"
+compute:
+  ollama: "Mac native (Metal GPU) - http://host.docker.internal:11435"
+  transformers: "Mac native (Metal) - http://host.docker.internal:8093"
+  redis: "Mac Docker - redis://mac-redis:6379"
 
 notes:
-  mode: "Full Mac stack running (Weaviate, Ollama, Transformers, Redis)"
-  cloud: "Cloud Weaviate accessible via API (if internet available)"
-  spark: "Full Spark access via Cloudflare tunnel (no SSH needed)"
-  tunnel: "Two Cloudflare tunnels: Mac (llm.pomothy.io) + Spark (spark-*.pomothy.io)"
+  mode: "Mac + Cloud (Spark offline)"
+  cloud: "Cloud Weaviate for prismatic production data"
+  mac: "Mac for compute (Ollama, Transformers) and local collections"
+  spark: "OFFLINE - switch to HOME mode when Spark is back"


### PR DESCRIPTION
## Summary
- Update OOO profile to use Mac compute with Cloud Weaviate (Spark offline)
- Update tenant routing with accurate collection counts

## Changes
- `profiles/ooo.env`: Switch to Mac Ollama, Mac Transformers, Mac Redis
- `tenant-routing/ooo.yaml`: Updated prismatic routing
  - Mac: Page_facts (937k), Page_content (84k)
  - Cloud: Research_* (40k+), Domain (29k), Opportunity (1.5k)
  - Spark services disabled

## Test plan
- [x] Verified Mac Weaviate collection counts
- [x] Verified Cloud Weaviate collection counts
- [x] pomai-backend-mac running with updated config

Made with [Cursor](https://cursor.com)