### PR TITLE
feat: add domain validation patterns and raw_page_count field

### DIFF
--- a/schemas/Research_competitor_schema.yaml
+++ b/schemas/Research_competitor_schema.yaml
@@ -219,6 +219,8 @@ properties:
   dataType:
   - text[]
   description: 'Primary domain for {subject}. Example: "competitor.com" (no https://, no www). Use "Not disclosed" if unknown.'
+  # Issue #868: Pattern constraint for LLM validation - prevents garbage like "domain.com (subdomain)"
+  pattern: '^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$|^Not disclosed$'
   parallel_to: keyCompetitors
   tags:
   - research

--- a/schemas/Research_customer_schema.yaml
+++ b/schemas/Research_customer_schema.yaml
@@ -139,6 +139,8 @@ properties:
   dataType:
   - text[]
   description: 'Primary domain for {subject}. Example: "customer.com" (no https://, no www). Use "Not disclosed" if unknown.'
+  # Issue #868: Pattern constraint for LLM validation - prevents garbage like "domain.com (subdomain)"
+  pattern: '^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$|^Not disclosed$'
   parallel_to: keyCustomers
   moduleConfig:
     text2vec-weaviate:

--- a/schemas/Research_partner_schema.yaml
+++ b/schemas/Research_partner_schema.yaml
@@ -221,6 +221,8 @@ properties:
   dataType:
   - text[]
   description: 'Primary domain for {subject}. Example: "partner.com" (no https://, no www). Use "Not disclosed" if unknown.'
+  # Issue #868: Pattern constraint for LLM validation - prevents garbage like "domain.com (subdomain)"
+  pattern: '^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$|^Not disclosed$'
   parallel_to: keyPartners
   moduleConfig:
     text2vec-weaviate:

--- a/schemas/domain_schema.yaml
+++ b/schemas/domain_schema.yaml
@@ -1069,7 +1069,22 @@ properties:
 - name: page_count
   dataType:
   - int
-  description: Count of Page_intelligence records (pages) discovered for this domain
+  # Issue #869: Clarified to mean actionable pages only (for completion metrics)
+  description: Count of actionable Page_Intelligence records (scrape_status IN ['scraped', 'pending'])
+  indexFilterable: true
+  sets:
+  - status_update
+  - system
+  tags:
+  - pipeline
+  - processing
+  - count
+
+# Issue #869: New field for total page count (no filtering)
+- name: raw_page_count
+  dataType:
+  - int
+  description: Total count of ALL Page_Intelligence records for this domain (no filtering by status)
   indexFilterable: true
   sets:
   - status_update


### PR DESCRIPTION
## Summary

- Add pattern constraints to `competitorDomain`, `customerDomain`, `partnerDomain` for LLM validation (fixes pom-core#868)
- Add `raw_page_count` field to Domain schema for total page count (fixes pom-core#869)
- Clarify `page_count` description to mean actionable pages only

## Changes

| File | Change |
|------|--------|
| `schemas/domain_schema.yaml` | Add `raw_page_count` field, clarify `page_count` description |
| `schemas/Research_competitor_schema.yaml` | Add pattern constraint to `competitorDomain` |
| `schemas/Research_customer_schema.yaml` | Add pattern constraint to `customerDomain` |
| `schemas/Research_partner_schema.yaml` | Add pattern constraint to `partnerDomain` |

## Test Plan

- [x] YAML validation passes (pre-commit hook)
- [ ] Schema loads correctly in pom-core CoreModelService


Made with [Cursor](https://cursor.com)