### PR TITLE
chore: enforce Cursor safety rules

### DIFF
--- a/.cursor/rules/no-destructive-git-without-explicit.mdc
+++ b/.cursor/rules/no-destructive-git-without-explicit.mdc
@@ -1,0 +1,10 @@
+---
+description: Block destructive git commands unless explicitly requested
+alwaysApply: true
+---
+
+# Destructive Git Safety
+
+- Never run destructive git commands unless explicitly requested in the user's message.
+- Destructive commands include: `git reset --hard`, `git checkout --`, `git clean -fd`, `git checkout --force`, `git push --force`, `git push -f`.
+- If a user requests such a command, confirm the exact repo and target before running it.

--- a/.cursor/rules/no-local-cleanup-ask.mdc
+++ b/.cursor/rules/no-local-cleanup-ask.mdc
@@ -1,0 +1,10 @@
+---
+description: Never offer or ask to clean up local uncommitted changes
+alwaysApply: true
+---
+
+# Local Changes Rule
+
+- Never offer to clean up, reset, or delete local uncommitted changes.
+- Never ask whether to clean up local uncommitted changes.
+- Always leave local uncommitted changes untouched unless the user explicitly requests cleanup in that message.


### PR DESCRIPTION
## Summary
- add always-apply rules to prevent cleanup prompts on local changes
- add always-apply rules to block destructive git commands
- keep rule text consistent across Pom repos

## Test plan
- Not run (rules-only)


Made with [Cursor](https://cursor.com)