### PR TITLE
feat: schema prompt property, prompty cleanup, researcher_ai chain reframe

### DIFF
--- a/prompts/default/classifiers/enum_classifier.prompty
+++ b/prompts/default/classifiers/enum_classifier.prompty
@@ -17,13 +17,6 @@ description: |
 
 prompt_type:
   name: cat_classifier
-  priority: 30
-  mode: chain
-  uses_execution_artifacts: true
-  outputs:
-    field_sets:
-      - EnumCat
-    include_cat_fields: true
 
 # === MODEL SELECTION CLASSIFICATION ===
 classification:

--- a/prompts/default/post_tools/array_domain_finder.prompty
+++ b/prompts/default/post_tools/array_domain_finder.prompty
@@ -10,13 +10,6 @@ category: enrich
 
 prompt_type:
   name: array_domain_finder
-  priority: 5
-  mode: chain
-  uses_execution_artifacts: true
-  outputs:
-    field_sets:
-      - post
-    allow_post_fields: true
 
 classification:
   task_type: extraction

--- a/prompts/default/post_tools/parallel_array_enricher.prompty
+++ b/prompts/default/post_tools/parallel_array_enricher.prompty
@@ -10,13 +10,6 @@ category: enrich
 
 prompt_type:
   name: array_enricher
-  priority: 10
-  mode: chain
-  uses_execution_artifacts: true
-  outputs:
-    field_sets:
-      - post
-    allow_post_fields: true
 
 classification:
   task_type: extraction

--- a/researcher_ai/competitor_ai.yaml
+++ b/researcher_ai/competitor_ai.yaml
@@ -142,11 +142,12 @@ parallel_array_enrichment:
   search_query_template: >
     {subject} official website
 
-# Post-execution tools: Run automatically after competitor researcher completes
-# Priority-ordered: lower number runs first
+# Prompt chain: prompt types executed in list order after the main researcher prompt.
+# Each link receives execution artifacts from the main prompt and prior links.
+# This is a chain definition — the list order defines implicit dependencies.
 post_execution_tools:
-  - parallel_array_enricher  # Priority 10: Fill post fields (uses parallel_array_enrichment config above)
-  - entity_spawn             # Priority 20: Create Domain records for competitors (requires competitorDomain)
-  - enum_cat                 # Priority 30: Classify EnumCat fields (competitorAnalysisCat, etc.)
-  - vec_cat                  # Priority 40: Classify VecCat fields (if any)
+  - parallel_array_enricher  # Enrich array_enricher fields (uses parallel_array_enrichment config above)
+  - entity_spawn             # Create Domain records for competitors (requires competitorDomain)
+  - enum_cat                 # Classify cat_classifier fields (competitorAnalysisCat, etc.)
+  - vec_cat                  # Classify vec_classifier fields (if any)
   # References are now generated automatically by schema_coercer on upsert

--- a/researcher_ai/customer_ai.yaml
+++ b/researcher_ai/customer_ai.yaml
@@ -125,10 +125,12 @@ parallel_array_enrichment:
   search_query_template: >
     {subject} official website
 
-# Post-execution tools for customer research
+# Prompt chain: prompt types executed in list order after the main researcher prompt.
+# Each link receives execution artifacts from the main prompt and prior links.
+# This is a chain definition — the list order defines implicit dependencies.
 post_execution_tools:
-  - parallel_array_enricher  # Finds customerDomain + evidence via search
+  - parallel_array_enricher  # Enrich array_enricher fields (customerDomain + evidence via search)
   - entity_spawn             # Creates Domain records for customers
-  - enum_cat                 # Classifies EnumCat fields
-  - vec_cat                  # Classifies VecCat fields
+  - enum_cat                 # Classify cat_classifier fields
+  - vec_cat                  # Classify vec_classifier fields
   - pdf_report_saver         # Generates report

--- a/researcher_ai/leadership_ai.yaml
+++ b/researcher_ai/leadership_ai.yaml
@@ -168,8 +168,9 @@ parallel_array_enrichment:
   search_query_template: >
     "{subject}" {executiveRoles} "{entityName}" site:linkedin.com/in
 
-# Post-execution tools: Run automatically after leadership researcher completes
-# Priority-ordered: lower number runs first
+# Prompt chain: prompt types executed in list order after the main researcher prompt.
+# Each link receives execution artifacts from the main prompt and prior links.
+# This is a chain definition — the list order defines implicit dependencies.
 post_execution_tools:
-  - parallel_array_enricher  # Priority 10: Fill post fields (uses parallel_array_enrichment config above)
-  - enum_cat                 # Priority 30: Classify EnumCat fields (leadershipStyleCat, etc.)
+  - parallel_array_enricher  # Enrich array_enricher fields (uses parallel_array_enrichment config above)
+  - enum_cat                 # Classify cat_classifier fields (leadershipStyleCat, etc.)

--- a/researcher_ai/partner_ai.yaml
+++ b/researcher_ai/partner_ai.yaml
@@ -114,10 +114,11 @@ parallel_array_enrichment:
   search_query_template: >
     {subject} official website
 
-# Post-execution tools: Run automatically after partner researcher completes
-# Priority-ordered: lower number runs first
+# Prompt chain: prompt types executed in list order after the main researcher prompt.
+# Each link receives execution artifacts from the main prompt and prior links.
+# This is a chain definition — the list order defines implicit dependencies.
 post_execution_tools:
-  - parallel_array_enricher  # Priority 10: Fill post fields (keyPartnerEvidence, partnerDomain)
-  - entity_spawn             # Priority 20: Create Domain records for partners
-  - enum_cat                 # Priority 30: Classify EnumCat fields (partnerTypeCat, etc.)
+  - parallel_array_enricher  # Enrich array_enricher fields (keyPartnerEvidence, partnerDomain)
+  - entity_spawn             # Create Domain records for partners
+  - enum_cat                 # Classify cat_classifier fields (partnerTypeCat, etc.)
   # References are now generated automatically by schema_coercer on upsert

--- a/researcher_ai/product_ai.yaml
+++ b/researcher_ai/product_ai.yaml
@@ -134,9 +134,10 @@ parallel_array_enrichment:
 
 citation_note: "No inline URLs in field values; put sources in CIT/evidence fields."
 
-# Post-execution tools for this researcher
-# Run in priority order after main LLM completes
+# Prompt chain: prompt types executed in list order after the main researcher prompt.
+# Each link receives execution artifacts from the main prompt and prior links.
+# This is a chain definition — the list order defines implicit dependencies.
 post_execution_tools:
-  - parallel_array_enricher  # Priority 10: Fill post fields (productCategories, productPricing, productFeatures, scores per product)
-  - enum_cat                 # Priority 30: Classify EnumCat fields (productDomain, technologyStackCat, pricingModelCat, etc.)
-  - vec_cat                  # Priority 40: Classify VecCat fields (productTypeCat)
+  - parallel_array_enricher  # Enrich array_enricher fields (productCategories, productPricing, productFeatures, scores per product)
+  - enum_cat                 # Classify cat_classifier fields (productDomain, technologyStackCat, pricingModelCat, etc.)
+  - vec_cat                  # Classify vec_classifier fields (productTypeCat)

--- a/schemas/Research_competitor_schema.yaml
+++ b/schemas/Research_competitor_schema.yaml
@@ -93,7 +93,8 @@ properties:
   - competitive
   sets:
   - standard
-  - EnumCat
+  prompt:
+  - cat_classifier
   metadata:
     order: 131
   label: Competitor Analysis
@@ -107,7 +108,8 @@ properties:
   sets:
   - standard
   - extended
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 132
 - name: competitorAnalysisCIT
@@ -120,8 +122,8 @@ properties:
   tags:
   - CIT
   - provenance
-  sets:
-  - prompt
+  prompt:
+  - main
   metadata:
     source_llm: competitorAnalysisLLM
     order: 133
@@ -147,7 +149,8 @@ properties:
   - research
   sets:
   - standard
-  - EnumCat
+  prompt:
+  - cat_classifier
   metadata:
     order: 133
   label: Market Position
@@ -162,7 +165,8 @@ properties:
   sets:
   - standard
   - extended
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 134
 - name: marketPositionCIT
@@ -175,8 +179,8 @@ properties:
   tags:
   - CIT
   - provenance
-  sets:
-  - prompt
+  prompt:
+  - main
   metadata:
     source_llm: marketPositionLLM
     order: 135
@@ -193,7 +197,8 @@ properties:
   - array
   - standard
   - spawn
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 201
     placeholder_values:
@@ -211,7 +216,8 @@ properties:
   sets:
   - array
   - standard
-  - post
+  prompt:
+  - array_enricher
   metadata:
     order: 207
   label: Advantages
@@ -229,7 +235,8 @@ properties:
   - array
   - standard
   - spawn
-  - post
+  prompt:
+  - array_domain_finder
   metadata:
     order: 202
   label: Domain
@@ -243,7 +250,8 @@ properties:
   sets:
   - array
   - standard
-  - post
+  prompt:
+  - array_enricher
   metadata:
     order: 206
   label: Gaps
@@ -257,7 +265,8 @@ properties:
   sets:
   - array
   - standard
-  - post
+  prompt:
+  - array_enricher
   metadata:
     order: 203
   label: Positioning
@@ -271,7 +280,8 @@ properties:
   sets:
   - array
   - standard
-  - post
+  prompt:
+  - array_enricher
   metadata:
     order: 205
   label: Price
@@ -285,7 +295,8 @@ properties:
   sets:
   - array
   - standard
-  - post
+  prompt:
+  - array_enricher
   metadata:
     order: 204
   label: Target Market
@@ -297,7 +308,8 @@ properties:
   sets:
   - array
   - extended
-  - post
+  prompt:
+  - array_enricher
   tags:
   - score
   metadata:
@@ -317,7 +329,8 @@ properties:
   sets:
   - array
   - system
-  - post
+  prompt:
+  - array_enricher
   metadata:
     order: 209
 - name: marketStrengthScore
@@ -328,7 +341,8 @@ properties:
   sets:
   - array
   - extended
-  - post
+  prompt:
+  - array_enricher
   tags:
   - score
   metadata:
@@ -342,7 +356,8 @@ properties:
   sets:
   - array
   - extended
-  - post
+  prompt:
+  - array_enricher
   tags:
   - score
   metadata:
@@ -358,7 +373,8 @@ properties:
   sets:
   - array
   - extended
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 122
   label: Competitive Advantages
@@ -370,7 +386,8 @@ properties:
   - research
   sets:
   - standard
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 111
 - name: competitivePositioning
@@ -381,7 +398,8 @@ properties:
   - research
   sets:
   - standard
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 121
 - name: competitiveThreats
@@ -394,7 +412,8 @@ properties:
   sets:
   - array
   - extended
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 124
 - name: differentiationFactors
@@ -407,7 +426,8 @@ properties:
   sets:
   - array
   - extended
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 123
   label: Differentiation Factors
@@ -435,7 +455,8 @@ properties:
   sets:
   - standard
   - extended
-  - prompt
+  prompt:
+  - main
   tags:
   - score
   metadata:
@@ -448,7 +469,8 @@ properties:
   sets:
   - standard
   - extended
-  - prompt
+  prompt:
+  - main
   tags:
   - score
   metadata:
@@ -461,7 +483,8 @@ properties:
   sets:
   - standard
   - extended
-  - prompt
+  prompt:
+  - main
   tags:
   - score
   metadata:
@@ -474,7 +497,8 @@ properties:
   - research
   sets:
   - extended
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 113
 - name: marketSize
@@ -485,7 +509,8 @@ properties:
   - research
   sets:
   - extended
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 112
 - name: marketTrends
@@ -498,7 +523,8 @@ properties:
   sets:
   - array
   - standard
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 114
   label: Market Trends
@@ -529,7 +555,8 @@ properties:
       skip: true
   sets:
   - system
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 901
 - name: sourceQuality
@@ -555,7 +582,8 @@ properties:
       skip: true
   sets:
   - system
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 902
 - name: page_facts_count
@@ -579,7 +607,8 @@ properties:
   sets:
   - array
   - system
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 904
 - name: domain
@@ -614,7 +643,8 @@ properties:
   sets:
   - array
   - system
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 907
 - name: processedDate
@@ -666,7 +696,8 @@ properties:
       skip: true
   sets:
   - system
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 911
 - name: updated_at

--- a/schemas/Research_customer_schema.yaml
+++ b/schemas/Research_customer_schema.yaml
@@ -82,7 +82,8 @@ properties:
   sets:
   - standard
   - extended
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 111
 - name: entityName
@@ -125,10 +126,11 @@ properties:
   - customer
   - research
   sets:
-  - prompt
   - standard
   - array
   - spawn
+  prompt:
+  - main
   metadata:
     order: 201
     placeholder_values:
@@ -152,8 +154,9 @@ properties:
   sets:
   - spawn
   - standard
-  - post
   - array
+  prompt:
+  - array_domain_finder
   metadata:
     order: 202
 - name: keyCustomerSizeCat
@@ -176,10 +179,11 @@ properties:
   - Cat
   - research
   sets:
-  - EnumCat
   - array
   - standard
-  - post
+  prompt:
+  - array_enricher
+  - cat_classifier
   metadata:
     order: 202
 - name: productUsed
@@ -193,8 +197,9 @@ properties:
   tags:
   - research
   sets:
-  - post
   - array
+  prompt:
+  - array_enricher
   metadata:
     order: 208
 - name: primaryUseCase
@@ -208,8 +213,9 @@ properties:
   tags:
   - research
   sets:
-  - post
   - array
+  prompt:
+  - array_enricher
   metadata:
     order: 209
 - name: keyCustomerEvidence
@@ -225,8 +231,9 @@ properties:
   - research
   - LLM
   sets:
-  - post
   - system
+  prompt:
+  - array_enricher
   metadata:
     order: 203
 - name: keyCustomerSizeEvidence
@@ -242,8 +249,9 @@ properties:
   - research
   - LLM
   sets:
-  - post
   - system
+  prompt:
+  - array_enricher
   metadata:
     order: 204
 - name: useCaseLLM
@@ -255,9 +263,10 @@ properties:
   - LLM
   - score
   sets:
-  - prompt
   - array
   - standard
+  prompt:
+  - main
   metadata:
     parallel_to: useCaseCat
     order: 132
@@ -271,8 +280,8 @@ properties:
   tags:
   - CIT
   - provenance
-  sets:
-  - prompt
+  prompt:
+  - main
   metadata:
     source_llm: useCaseLLM
     order: 133
@@ -283,8 +292,9 @@ properties:
   tags:
   - research
   sets:
-  - prompt
   - array
+  prompt:
+  - main
   metadata:
     order: 141
 - name: valueProposition
@@ -297,7 +307,8 @@ properties:
   - extractable
   sets:
   - extended
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 112
 - name: customerSuccess
@@ -308,7 +319,8 @@ properties:
   - research
   sets:
   - extended
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 113
 - name: caseStudies
@@ -319,8 +331,9 @@ properties:
   tags:
   - research
   sets:
-  - post
   - array
+  prompt:
+  - array_enricher
   metadata:
     order: 210
 - name: growthOpportunity
@@ -331,7 +344,8 @@ properties:
   - research
   sets:
   - extended
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 114
 - name: customerSizeCat
@@ -352,7 +366,8 @@ properties:
   - benchmark
   sets:
   - standard
-  - EnumCat
+  prompt:
+  - cat_classifier
   metadata:
     order: 121
 - name: customerSectorCat
@@ -386,7 +401,8 @@ properties:
   - industry
   sets:
   - standard
-  - EnumCat
+  prompt:
+  - cat_classifier
   metadata:
     order: 122
 - name: customerNAICS
@@ -401,7 +417,8 @@ properties:
   - LLM
   sets:
   - standard
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 123
 - name: useCaseCat
@@ -417,55 +434,11 @@ properties:
   - score
   sets:
   - standard
-  - VecCat
+  prompt:
+  - vec_classifier
   metadata:
     parallel_anchor: true
     order: 131
-- name: useCaseSimilarities
-  dataType:
-  - number[]
-  description: Similarity scores for each classified use case (ordered highest to lowest, [0] is primary)
-  moduleConfig:
-    text2vec-weaviate:
-      skip: true
-  tags:
-  - metadata
-  - classification
-  - score
-  sets:
-  - system
-  metadata:
-    parallel_to: useCaseCat
-    order: 134
-- name: useCaseMatchedSeeds
-  dataType:
-  - text[]
-  description: Names of seed records matched for each use case ([0] is primary)
-  moduleConfig:
-    text2vec-weaviate:
-      skip: true
-  tags:
-  - metadata
-  - classification
-  sets:
-  - system
-  metadata:
-    parallel_to: useCaseCat
-    order: 135
-- name: useCaseThreshold
-  dataType:
-  - number
-  description: Similarity threshold used for multi-use-case classification (typically 0.15)
-  moduleConfig:
-    text2vec-weaviate:
-      skip: true
-  tags:
-  - metadata
-  - classification
-  sets:
-  - system
-  metadata:
-    order: 136
 - name: customerRegionCat
   dataType:
   - text
@@ -486,7 +459,8 @@ properties:
   sets:
   - system
   - standard
-  - EnumCat
+  prompt:
+  - cat_classifier
   metadata:
     order: 124
 - name: customerSector
@@ -518,8 +492,9 @@ properties:
   - research
   - industry
   sets:
-  - prompt
   - standard
+  prompt:
+  - main
   metadata:
     order: 125
 - name: customerIndustry
@@ -562,8 +537,9 @@ properties:
   - research
   - industry
   sets:
-  - prompt
   - standard
+  prompt:
+  - main
   metadata:
     order: 126
 - name: customerIndustrySegmentLLM
@@ -576,9 +552,10 @@ properties:
   - industry
   - segment
   sets:
-  - prompt
   - extended
   - standard
+  prompt:
+  - main
   metadata:
     order: 127
 - name: customerIndustrySegmentCIT
@@ -591,8 +568,8 @@ properties:
   tags:
   - CIT
   - provenance
-  sets:
-  - prompt
+  prompt:
+  - main
   metadata:
     source_llm: customerIndustrySegmentLLM
     order: 128
@@ -608,8 +585,9 @@ properties:
   - segment
   sets:
   - standard
-  - VecCat
   - extended
+  prompt:
+  - vec_classifier
   metadata:
     classifier_collection: Research_industry
     classifier_vector: industrySegmentVector
@@ -634,7 +612,8 @@ properties:
   - score
   sets:
   - standard
-  - EnumCat
+  prompt:
+  - cat_classifier
   metadata:
     parallel_to: useCaseCat
     order: 133
@@ -671,9 +650,10 @@ properties:
   - research
   - industry
   sets:
-  - EnumCat
   - array
   - standard
+  prompt:
+  - cat_classifier
   metadata:
     order: 203
 - name: keyCustomerNAICS
@@ -689,9 +669,10 @@ properties:
   - industry
   - LLM
   sets:
-  - post
   - array
   - extended
+  prompt:
+  - array_enricher
   metadata:
     order: 205
 - name: keyCustomerIndustryCat
@@ -738,9 +719,10 @@ properties:
   - research
   - industry
   sets:
-  - EnumCat
   - array
   - standard
+  prompt:
+  - cat_classifier
   metadata:
     order: 204
 - name: keyCustomerIndustrySegmentLLM
@@ -757,9 +739,10 @@ properties:
   - industry
   - segment
   sets:
-  - post
   - array
   - extended
+  prompt:
+  - array_enricher
   metadata:
     order: 206
 - name: keyCustomerIndustrySegmentCIT
@@ -772,8 +755,8 @@ properties:
   tags:
   - CIT
   - provenance
-  sets:
-  - post
+  prompt:
+  - array_enricher
   metadata:
     source_llm: keyCustomerIndustrySegmentLLM
     order: 207
@@ -793,7 +776,8 @@ properties:
   - score
   sets:
   - standard
-  - VecCat
+  prompt:
+  - vec_classifier
   metadata:
     parallel_to: keyCustomers
     classifier_collection: Research_industry
@@ -829,7 +813,8 @@ properties:
   - extended
   - metadata
   - system
-  - prompt
+  prompt:
+  - main
   tags:
   - confidence
   metadata:
@@ -857,7 +842,8 @@ properties:
       skip: true
   sets:
   - system
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 902
 - name: reviewFlag
@@ -882,7 +868,8 @@ properties:
   - extended
   - metadata
   - system
-  - prompt
+  prompt:
+  - main
   tags:
   - review
   metadata:
@@ -926,7 +913,8 @@ properties:
   - system
   - metadata
   - extended
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 904
 - name: researcher_model_id
@@ -952,8 +940,8 @@ properties:
   - number[]
   description: Account size/revenue potential score per key customer (1-10)
   parallel_to: keyCustomers
-  sets:
-  - post
+  prompt:
+  - array_enricher
   tags:
   - score
   metadata:
@@ -963,8 +951,8 @@ properties:
   - number[]
   description: Strategic value score per key customer (1-10)
   parallel_to: keyCustomers
-  sets:
-  - post
+  prompt:
+  - array_enricher
   tags:
   - score
   metadata:
@@ -974,8 +962,8 @@ properties:
   - number[]
   description: Expansion potential score per key customer (1-10)
   parallel_to: keyCustomers
-  sets:
-  - post
+  prompt:
+  - array_enricher
   tags:
   - score
   metadata:

--- a/schemas/Research_financial_schema.yaml
+++ b/schemas/Research_financial_schema.yaml
@@ -132,7 +132,8 @@ properties:
   - research
   sets:
   - standard
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 131
 - name: financialHealth
@@ -145,7 +146,8 @@ properties:
   - research
   sets:
   - extended
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 112
 - name: revenueProfile
@@ -156,7 +158,8 @@ properties:
   - research
   sets:
   - extended
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 111
 - name: fundingRounds
@@ -172,7 +175,8 @@ properties:
   sets:
   - array
   - standard
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 201
     parallel_anchor: true
@@ -186,8 +190,9 @@ properties:
   sets:
   - array
   - standard
-  - prompt
   - standard
+  prompt:
+  - main
   metadata:
     parallel_to: fundingRounds
     order: 202
@@ -201,8 +206,9 @@ properties:
   sets:
   - array
   - standard
-  - prompt
   - standard
+  prompt:
+  - main
   metadata:
     parallel_to: fundingRounds
     order: 203
@@ -217,8 +223,9 @@ properties:
   sets:
   - array
   - standard
-  - prompt
   - standard
+  prompt:
+  - main
   metadata:
     parallel_to: fundingRounds
     order: 204
@@ -233,7 +240,8 @@ properties:
   sets:
   - array
   - system
-  - post
+  prompt:
+  - array_enricher
   metadata:
     order: 902
 - name: growthVelocityLLM
@@ -245,7 +253,8 @@ properties:
   - LLM
   sets:
   - extended
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 126
 - name: growthVelocityCIT
@@ -258,8 +267,8 @@ properties:
   tags:
   - CIT
   - provenance
-  sets:
-  - prompt
+  prompt:
+  - main
   metadata:
     source_llm: growthVelocityLLM
     order: 127
@@ -272,9 +281,10 @@ properties:
   - LLM
   sets:
   - standard
-  - prompt
   - extended
   - standard
+  prompt:
+  - main
   metadata:
     order: 128
 - name: profitabilityProfileCIT
@@ -287,8 +297,8 @@ properties:
   tags:
   - CIT
   - provenance
-  sets:
-  - prompt
+  prompt:
+  - main
   metadata:
     source_llm: profitabilityProfileLLM
     order: 129
@@ -301,9 +311,10 @@ properties:
   - LLM
   sets:
   - standard
-  - prompt
   - extended
   - standard
+  prompt:
+  - main
   metadata:
     order: 122
 - name: revenueSizeCIT
@@ -316,8 +327,8 @@ properties:
   tags:
   - CIT
   - provenance
-  sets:
-  - prompt
+  prompt:
+  - main
   metadata:
     source_llm: revenueSizeLLM
     order: 123
@@ -367,9 +378,10 @@ properties:
   - LLM
   sets:
   - standard
-  - prompt
   - extended
   - standard
+  prompt:
+  - main
   metadata:
     order: 124
 - name: fundingStageCIT
@@ -382,8 +394,8 @@ properties:
   tags:
   - CIT
   - provenance
-  sets:
-  - prompt
+  prompt:
+  - main
   metadata:
     source_llm: fundingStageLLM
     order: 125
@@ -395,7 +407,8 @@ properties:
   - research
   sets:
   - extended
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 132
 - name: revenueGrowthRate
@@ -406,7 +419,8 @@ properties:
   - research
   sets:
   - extended
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 133
 - name: totalFunding
@@ -417,7 +431,8 @@ properties:
   - research
   sets:
   - standard
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 134
 - name: keyInvestors
@@ -431,8 +446,9 @@ properties:
   sets:
   - array
   - standard
-  - prompt
   - extended
+  prompt:
+  - main
   metadata:
     order: 203
 - name: valuation
@@ -443,7 +459,8 @@ properties:
   - research
   sets:
   - extended
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 135
 - name: fundingStageCat
@@ -472,7 +489,8 @@ properties:
   - standard
   - system
   - standard
-  - EnumCat
+  prompt:
+  - cat_classifier
   metadata:
     source_llm: fundingStageLLM
     order: 123
@@ -500,8 +518,9 @@ properties:
   - standard
   - system
   - standard
-  - EnumCat
   - extended
+  prompt:
+  - cat_classifier
   metadata:
     source_llm: revenueSizeLLM
     order: 121
@@ -554,7 +573,8 @@ properties:
   - growth
   sets:
   - extended
-  - EnumCat
+  prompt:
+  - cat_classifier
   metadata:
     source_llm: growthVelocityLLM
     order: 125
@@ -604,7 +624,8 @@ properties:
   - profitability
   sets:
   - extended
-  - EnumCat
+  prompt:
+  - cat_classifier
   metadata:
     source_llm: profitabilityProfileLLM
     order: 127
@@ -618,7 +639,8 @@ properties:
   sets:
   - standard
   - standard
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 141
 - name: headcountGrowthCat
@@ -655,7 +677,8 @@ properties:
   - headcount
   sets:
   - extended
-  - EnumCat
+  prompt:
+  - cat_classifier
   metadata:
     order: 142
 - name: processedDate
@@ -694,7 +717,8 @@ properties:
   sets:
   - system
   - standard
-  - prompt
+  prompt:
+  - main
   tags:
   - confidence
   metadata:
@@ -722,7 +746,8 @@ properties:
       skip: true
   sets:
   - system
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 902
 - name: reviewFlag
@@ -746,7 +771,8 @@ properties:
   sets:
   - system
   - standard
-  - prompt
+  prompt:
+  - main
   tags:
   - review
   metadata:
@@ -771,7 +797,8 @@ properties:
       skip: true
   sets:
   - system
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 904
 - name: researcher_model_id

--- a/schemas/Research_industry_schema.yaml
+++ b/schemas/Research_industry_schema.yaml
@@ -185,7 +185,8 @@ properties:
   - score
   sets:
   - standard
-  - EnumCat
+  prompt:
+  - cat_classifier
   metadata:
     source_llm: businessModelLLM
     order: 111
@@ -198,9 +199,10 @@ properties:
   - LLM
   - score
   sets:
-  - prompt
   - array
   - standard
+  prompt:
+  - main
   metadata:
     order: 112
 - name: businessModelCIT
@@ -213,8 +215,8 @@ properties:
   tags:
   - CIT
   - provenance
-  sets:
-  - prompt
+  prompt:
+  - main
   metadata:
     source_llm: businessModelLLM
     order: 113
@@ -239,7 +241,8 @@ properties:
   - score
   sets:
   - standard
-  - EnumCat
+  prompt:
+  - cat_classifier
   metadata:
     source_llm: deliveryModelLLM
     order: 121
@@ -252,9 +255,10 @@ properties:
   - LLM
   - score
   sets:
-  - prompt
   - array
   - standard
+  prompt:
+  - main
   metadata:
     order: 122
 - name: deliveryModelCIT
@@ -267,8 +271,8 @@ properties:
   tags:
   - CIT
   - provenance
-  sets:
-  - prompt
+  prompt:
+  - main
   metadata:
     source_llm: deliveryModelLLM
     order: 123
@@ -285,7 +289,8 @@ properties:
   - score
   sets:
   - standard
-  - VecCat
+  prompt:
+  - vec_classifier
   metadata:
     order: 131
     source_llm: industrySegmentLLM
@@ -298,9 +303,10 @@ properties:
   - LLM
   - score
   sets:
-  - prompt
   - array
   - standard
+  prompt:
+  - main
   metadata:
     order: 132
 - name: industrySegmentCIT
@@ -313,8 +319,8 @@ properties:
   tags:
   - CIT
   - provenance
-  sets:
-  - prompt
+  prompt:
+  - main
   metadata:
     source_llm: industrySegmentLLM
     order: 133
@@ -341,8 +347,8 @@ properties:
   - research
   - contextual
   - extractable
-  sets:
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 301
 - name: entityId
@@ -409,7 +415,8 @@ properties:
   - score
   sets:
   - standard
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 303
 - name: naicsCode
@@ -424,7 +431,8 @@ properties:
   - score
   sets:
   - array
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 201
 - name: naicsDescription
@@ -437,7 +445,8 @@ properties:
   - score
   sets:
   - array
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 202
 - name: sector
@@ -468,7 +477,8 @@ properties:
   - score
   sets:
   - standard
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 304
 - name: valueChainPosition
@@ -477,8 +487,8 @@ properties:
   description: Entity's position in the value chain
   tags:
   - research
-  sets:
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 305
 - name: analysisConfidence
@@ -487,7 +497,8 @@ properties:
   description: Confidence level of analysis (high/medium/low/inferred/web_verified)
   sets:
   - system
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 901
 - name: sourceQuality
@@ -513,7 +524,8 @@ properties:
       skip: true
   sets:
   - system
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 902
 - name: page_facts_count
@@ -536,7 +548,8 @@ properties:
       skip: true
   sets:
   - system
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 904
 - name: processedDate
@@ -570,7 +583,8 @@ properties:
   description: Review flag for human validation (none/for_review/needs_verification)
   sets:
   - system
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 912
 - name: updated_at

--- a/schemas/Research_journalist_schema.yaml
+++ b/schemas/Research_journalist_schema.yaml
@@ -128,8 +128,8 @@ properties:
   description: Type of media content (press-release, news-article, interview, media-kit)
   tags:
   - research
-  sets:
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 115
 - name: mediaOutlets
@@ -144,7 +144,8 @@ properties:
   - research
   sets:
   - array
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 201
 - name: pressReleaseCount
@@ -153,8 +154,8 @@ properties:
   description: Number of press releases found
   tags:
   - research
-  sets:
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 124
 - name: newsArticleCount
@@ -163,8 +164,8 @@ properties:
   description: Number of news articles found
   tags:
   - research
-  sets:
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 125
 - name: latestNewsDate
@@ -177,7 +178,8 @@ properties:
   - research
   sets:
   - extended
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 121
 - name: recentNewsCount
@@ -190,7 +192,8 @@ properties:
   - volume
   sets:
   - extended
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 122
 - name: newsRecency
@@ -203,7 +206,8 @@ properties:
   - research
   sets:
   - extended
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 123
 - name: mediaCoverageScore
@@ -213,8 +217,8 @@ properties:
   tags:
   - research
   - score
-  sets:
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 116
 - name: hasMediaKit
@@ -224,8 +228,9 @@ properties:
   tags:
   - research
   sets:
-  - prompt
   - extended
+  prompt:
+  - main
   metadata:
     order: 117
 - name: hasNewsroom
@@ -234,8 +239,8 @@ properties:
   description: Has dedicated newsroom section
   tags:
   - research
-  sets:
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 118
 - name: mediaSentiment
@@ -244,8 +249,8 @@ properties:
   description: Overall sentiment of media coverage (positive, neutral, negative)
   tags:
   - research
-  sets:
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 111
 - name: mediaTypeLLM
@@ -256,9 +261,10 @@ properties:
   tags:
   - LLM
   sets:
-  - prompt
   - extended
   - standard
+  prompt:
+  - main
   metadata:
     order: 132
 - name: mediaTypeCIT
@@ -271,8 +277,8 @@ properties:
   tags:
   - CIT
   - provenance
-  sets:
-  - prompt
+  prompt:
+  - main
   metadata:
     source_llm: mediaTypeLLM
     order: 133
@@ -284,9 +290,10 @@ properties:
   tags:
   - LLM
   sets:
-  - prompt
   - extended
   - standard
+  prompt:
+  - main
   metadata:
     order: 134
 - name: coverageLevelCIT
@@ -299,8 +306,8 @@ properties:
   tags:
   - CIT
   - provenance
-  sets:
-  - prompt
+  prompt:
+  - main
   metadata:
     source_llm: coverageLevelLLM
     order: 135
@@ -313,9 +320,10 @@ properties:
   - LLM
   - research
   sets:
-  - prompt
   - extended
   - standard
+  prompt:
+  - main
   metadata:
     order: 136
 - name: mediaSentimentCIT
@@ -328,8 +336,8 @@ properties:
   tags:
   - CIT
   - provenance
-  sets:
-  - prompt
+  prompt:
+  - main
   metadata:
     source_llm: mediaSentimentLLM
     order: 137
@@ -349,8 +357,9 @@ properties:
   - research
   sets:
   - extended
-  - prompt
   - standard
+  prompt:
+  - main
   metadata:
     order: 112
 - name: newsMomentum
@@ -369,7 +378,8 @@ properties:
   - research
   sets:
   - extended
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 113
 - name: credibilitySignals
@@ -388,7 +398,8 @@ properties:
   - research
   sets:
   - extended
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 114
 - name: mediaTypeCat
@@ -411,7 +422,8 @@ properties:
   - media
   sets:
   - standard
-  - EnumCat
+  prompt:
+  - cat_classifier
   metadata:
     order: 131
 - name: coverageLevelCat
@@ -432,7 +444,8 @@ properties:
   - coverage
   sets:
   - standard
-  - EnumCat
+  prompt:
+  - cat_classifier
   metadata:
     order: 133
 - name: mediaSentimentCat
@@ -455,7 +468,8 @@ properties:
   - sentiment
   sets:
   - standard
-  - EnumCat
+  prompt:
+  - cat_classifier
   metadata:
     order: 135
 - name: processedDate
@@ -486,7 +500,8 @@ properties:
       skip: true
   sets:
   - system
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 910
 - name: analysisConfidence
@@ -516,7 +531,8 @@ properties:
       skip: true
   sets:
   - system
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 901
 - name: sourceQuality
@@ -542,7 +558,8 @@ properties:
       skip: true
   sets:
   - system
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 902
 - name: page_facts_count
@@ -565,7 +582,8 @@ properties:
       skip: true
   sets:
   - system
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 904
 - name: researcher_model_id

--- a/schemas/Research_leadership_schema.yaml
+++ b/schemas/Research_leadership_schema.yaml
@@ -122,9 +122,10 @@ properties:
   - LLM
   - research
   sets:
-  - prompt
   - extended
   - standard
+  prompt:
+  - main
   metadata:
     order: 122
 - name: founderProfileCIT
@@ -137,8 +138,8 @@ properties:
   tags:
   - CIT
   - provenance
-  sets:
-  - prompt
+  prompt:
+  - main
   metadata:
     source_llm: founderProfileLLM
     order: 123
@@ -152,8 +153,9 @@ properties:
   - research
   sets:
   - extended
-  - prompt
   - standard
+  prompt:
+  - main
   metadata:
     order: 111
 - name: ceoBackground
@@ -163,8 +165,9 @@ properties:
   tags:
   - research
   sets:
-  - prompt
   - standard
+  prompt:
+  - main
   metadata:
     order: 112
 - name: ceoTenure
@@ -174,8 +177,9 @@ properties:
   tags:
   - research
   sets:
-  - prompt
   - standard
+  prompt:
+  - main
   metadata:
     order: 113
 - name: founderStatus
@@ -185,8 +189,9 @@ properties:
   tags:
   - research
   sets:
-  - prompt
   - standard
+  prompt:
+  - main
   metadata:
     order: 114
 - name: executiveTeamSize
@@ -196,8 +201,9 @@ properties:
   tags:
   - research
   sets:
-  - prompt
   - standard
+  prompt:
+  - main
   metadata:
     order: 115
 - name: employeeCount
@@ -227,7 +233,8 @@ properties:
   - headcount
   sets:
   - standard
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 116
 - name: employeeSizeCat
@@ -271,7 +278,8 @@ properties:
   - headcount
   sets:
   - extended
-  - EnumCat
+  prompt:
+  - cat_classifier
   metadata:
     order: 117
 - name: executiveExperienceLLM
@@ -283,9 +291,10 @@ properties:
   - LLM
   - research
   sets:
-  - prompt
   - extended
   - standard
+  prompt:
+  - main
   metadata:
     order: 124
 - name: executiveExperienceCIT
@@ -298,8 +307,8 @@ properties:
   tags:
   - CIT
   - provenance
-  sets:
-  - prompt
+  prompt:
+  - main
   metadata:
     source_llm: executiveExperienceLLM
     order: 125
@@ -319,8 +328,9 @@ properties:
   - research
   sets:
   - array
-  - prompt
   - standard
+  prompt:
+  - main
   metadata:
     order: 201
     placeholder_values:
@@ -355,7 +365,8 @@ properties:
   sets:
   - array
   - system
-  - post
+  prompt:
+  - array_enricher
   metadata:
     order: 916
 - name: executiveBackgrounds
@@ -369,8 +380,9 @@ properties:
   - research
   sets:
   - array
-  - post
   - standard
+  prompt:
+  - array_enricher
   metadata:
     order: 203
 - name: executiveRoles
@@ -384,8 +396,9 @@ properties:
   - research
   sets:
   - array
-  - post
   - standard
+  prompt:
+  - array_enricher
   metadata:
     order: 202
 - name: executiveTenure
@@ -399,8 +412,9 @@ properties:
   - research
   sets:
   - array
-  - post
   - standard
+  prompt:
+  - array_enricher
   metadata:
     order: 204
 - name: executiveLinkedIn
@@ -413,9 +427,10 @@ properties:
   - linkedin
   sets:
   - array
-  - post
   - extended
   - standard
+  prompt:
+  - array_enricher
   metadata:
     order: 205
 - name: leadershipStyleLLM
@@ -427,9 +442,10 @@ properties:
   - LLM
   - research
   sets:
-  - prompt
   - extended
   - standard
+  prompt:
+  - main
   metadata:
     order: 126
 - name: leadershipStyleCIT
@@ -442,8 +458,8 @@ properties:
   tags:
   - CIT
   - provenance
-  sets:
-  - prompt
+  prompt:
+  - main
   metadata:
     source_llm: leadershipStyleLLM
     order: 127
@@ -457,7 +473,8 @@ properties:
   - research
   sets:
   - extended
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 127
 - name: advisors
@@ -476,7 +493,8 @@ properties:
   - research
   sets:
   - array
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 206
     placeholder_values:
@@ -505,7 +523,8 @@ properties:
   - research
   sets:
   - standard
-  - EnumCat
+  prompt:
+  - cat_classifier
   metadata:
     order: 121
 - name: executiveExperienceCat
@@ -529,7 +548,8 @@ properties:
   - research
   sets:
   - standard
-  - EnumCat
+  prompt:
+  - cat_classifier
   metadata:
     order: 123
 - name: leadershipStyleCat
@@ -554,7 +574,8 @@ properties:
   - research
   sets:
   - standard
-  - EnumCat
+  prompt:
+  - cat_classifier
   metadata:
     order: 125
 - name: processedDate
@@ -592,7 +613,8 @@ properties:
       skip: true
   sets:
   - system
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 901
 - name: sourceQuality
@@ -618,7 +640,8 @@ properties:
       skip: true
   sets:
   - system
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 902
 - name: reviewFlag
@@ -641,7 +664,8 @@ properties:
       skip: true
   sets:
   - system
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 910
 - name: page_facts_count
@@ -664,7 +688,8 @@ properties:
       skip: true
   sets:
   - system
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 904
 - name: researcher_model_id
@@ -702,7 +727,8 @@ properties:
   - number[]
   sets:
   - array
-  - prompt
+  prompt:
+  - main
   moduleConfig:
     text2vec-weaviate:
       skip: true
@@ -716,7 +742,8 @@ properties:
   - number[]
   sets:
   - array
-  - prompt
+  prompt:
+  - main
   moduleConfig:
     text2vec-weaviate:
       skip: true
@@ -730,8 +757,9 @@ properties:
   - number
   sets:
   - extended
-  - prompt
   - standard
+  prompt:
+  - main
   tags:
   - research
   metadata:
@@ -742,7 +770,8 @@ properties:
   - number[]
   sets:
   - array
-  - prompt
+  prompt:
+  - main
   moduleConfig:
     text2vec-weaviate:
       skip: true

--- a/schemas/Research_partner_schema.yaml
+++ b/schemas/Research_partner_schema.yaml
@@ -119,9 +119,10 @@ properties:
   tags:
   - LLM
   sets:
-  - prompt
   - extended
   - standard
+  prompt:
+  - main
   metadata:
     order: 111
 - name: partnerTypeCIT
@@ -134,8 +135,8 @@ properties:
   tags:
   - CIT
   - provenance
-  sets:
-  - prompt
+  prompt:
+  - main
   metadata:
     source_llm: partnerTypeLLM
     order: 112
@@ -152,8 +153,9 @@ properties:
   sets:
   - standard
   - array
-  - prompt
   - spawn
+  prompt:
+  - main
   metadata:
     order: 201
     placeholder_values:
@@ -187,7 +189,8 @@ properties:
   sets:
   - array
   - system
-  - post
+  prompt:
+  - array_enricher
   metadata:
     order: 916
 - name: partnerTypes
@@ -201,7 +204,8 @@ properties:
   - web
   sets:
   - array
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 202
 - name: partnerValue
@@ -214,7 +218,8 @@ properties:
   - research
   sets:
   - array
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 204
 - name: partnerDomain
@@ -234,7 +239,8 @@ properties:
   sets:
   - array
   - spawn
-  - post
+  prompt:
+  - array_domain_finder
   metadata:
     order: 205
 - name: integrationLLM
@@ -245,9 +251,10 @@ properties:
   tags:
   - LLM
   sets:
-  - prompt
   - extended
   - standard
+  prompt:
+  - main
   metadata:
     order: 113
 - name: integrationCIT
@@ -260,8 +267,8 @@ properties:
   tags:
   - CIT
   - provenance
-  sets:
-  - prompt
+  prompt:
+  - main
   metadata:
     source_llm: integrationLLM
     order: 114
@@ -275,7 +282,8 @@ properties:
   - technical
   sets:
   - array
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 203
 - name: marketplacePresence
@@ -288,7 +296,8 @@ properties:
   - research
   sets:
   - array
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 205
 - name: ecosystemRole
@@ -301,7 +310,8 @@ properties:
   - research
   sets:
   - extended
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 114
 - name: revenueImpactLLM
@@ -312,9 +322,10 @@ properties:
   tags:
   - LLM
   sets:
-  - prompt
   - extended
   - standard
+  prompt:
+  - main
   metadata:
     order: 115
 - name: revenueImpactCIT
@@ -327,8 +338,8 @@ properties:
   tags:
   - CIT
   - provenance
-  sets:
-  - prompt
+  prompt:
+  - main
   metadata:
     source_llm: revenueImpactLLM
     order: 116
@@ -338,8 +349,8 @@ properties:
   description: Partnership revenue model and monetization approach
   tags:
   - research
-  sets:
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 115
 - name: partnerEcosystem
@@ -348,8 +359,8 @@ properties:
   description: Overall partner ecosystem analysis including network effects and ecosystem value
   tags:
   - research
-  sets:
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 116
 - name: partnerTypeCat
@@ -372,7 +383,8 @@ properties:
   - partner
   sets:
   - standard
-  - EnumCat
+  prompt:
+  - cat_classifier
   metadata:
     order: 121
 - name: integrationCat
@@ -394,7 +406,8 @@ properties:
   - technical
   sets:
   - standard
-  - EnumCat
+  prompt:
+  - cat_classifier
   metadata:
     order: 122
 - name: revenueImpactCat
@@ -416,7 +429,8 @@ properties:
   - revenue
   sets:
   - standard
-  - EnumCat
+  prompt:
+  - cat_classifier
   metadata:
     order: 123
 - name: processedDate
@@ -447,7 +461,8 @@ properties:
       skip: true
   sets:
   - system
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 910
 - name: analysisConfidence
@@ -477,7 +492,8 @@ properties:
       skip: true
   sets:
   - system
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 901
 - name: sourceQuality
@@ -503,7 +519,8 @@ properties:
       skip: true
   sets:
   - system
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 902
 - name: page_facts_count
@@ -526,7 +543,8 @@ properties:
       skip: true
   sets:
   - system
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 904
 - name: researcher_model_id

--- a/schemas/Research_product_schema.yaml
+++ b/schemas/Research_product_schema.yaml
@@ -210,7 +210,8 @@ properties:
   sets:
   - standard
   - extended
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 111
 - name: productTypeLLM
@@ -221,9 +222,10 @@ properties:
   tags:
   - LLM
   sets:
-  - prompt
   - array
   - standard
+  prompt:
+  - main
   metadata:
     order: 122
 - name: productTypeCIT
@@ -236,8 +238,8 @@ properties:
   tags:
   - CIT
   - provenance
-  sets:
-  - prompt
+  prompt:
+  - main
   metadata:
     source_llm: productTypeLLM
     order: 123
@@ -255,53 +257,10 @@ properties:
   - score
   sets:
   - standard
-  - VecCat
+  prompt:
+  - vec_classifier
   metadata:
     order: 121
-- name: productTypeSimilarities
-  dataType:
-  - number[]
-  description: Similarity scores for each classified product type (ordered highest to lowest,
-    [0] is primary)
-  moduleConfig:
-    text2vec-weaviate:
-      skip: true
-  tags:
-  - metadata
-  - classification
-  - score
-  sets:
-  - system
-  metadata:
-    order: 916
-- name: productTypeMatchedSeeds
-  dataType:
-  - text[]
-  description: Names of seed records matched for each product type ([0] is primary)
-  moduleConfig:
-    text2vec-weaviate:
-      skip: true
-  tags:
-  - metadata
-  - classification
-  sets:
-  - system
-  metadata:
-    order: 917
-- name: productTypeThreshold
-  dataType:
-  - number
-  description: Similarity threshold used for multi-product-type classification (typically 0.15)
-  moduleConfig:
-    text2vec-weaviate:
-      skip: true
-  tags:
-  - metadata
-  - classification
-  sets:
-  - system
-  metadata:
-    order: 918
 - name: productDomain
   dataType:
   - text[]
@@ -322,7 +281,8 @@ properties:
   - product
   sets:
   - standard
-  - EnumCat
+  prompt:
+  - cat_classifier
   metadata:
     source_llm: productTypeLLM
     order: 123
@@ -335,9 +295,10 @@ properties:
   - LLM
   - score
   sets:
-  - prompt
   - array
   - standard
+  prompt:
+  - main
   metadata:
     order: 125
 - name: technologyStackCIT
@@ -350,8 +311,8 @@ properties:
   tags:
   - CIT
   - provenance
-  sets:
-  - prompt
+  prompt:
+  - main
   metadata:
     source_llm: technologyStackLLM
     order: 126
@@ -375,7 +336,8 @@ properties:
   - technology
   sets:
   - standard
-  - EnumCat
+  prompt:
+  - cat_classifier
   metadata:
     source_llm: technologyStackLLM
     order: 124
@@ -387,9 +349,10 @@ properties:
   tags:
   - LLM
   sets:
-  - prompt
   - extended
   - standard
+  prompt:
+  - main
   metadata:
     order: 132
 - name: pricingModelCIT
@@ -402,8 +365,8 @@ properties:
   tags:
   - CIT
   - provenance
-  sets:
-  - prompt
+  prompt:
+  - main
   metadata:
     source_llm: pricingModelLLM
     order: 133
@@ -456,8 +419,9 @@ properties:
   - pricing
   sets:
   - standard
-  - EnumCat
   - extended
+  prompt:
+  - cat_classifier
   metadata:
     source_llm: pricingModelLLM
     order: 131
@@ -469,9 +433,10 @@ properties:
   tags:
   - LLM
   sets:
-  - prompt
   - extended
   - standard
+  prompt:
+  - main
   metadata:
     order: 134
 - name: integrationProfileCIT
@@ -484,8 +449,8 @@ properties:
   tags:
   - CIT
   - provenance
-  sets:
-  - prompt
+  prompt:
+  - main
   metadata:
     source_llm: integrationProfileLLM
     order: 135
@@ -535,8 +500,9 @@ properties:
   - integration
   sets:
   - standard
-  - EnumCat
   - extended
+  prompt:
+  - cat_classifier
   metadata:
     source_llm: integrationProfileLLM
     order: 133
@@ -550,7 +516,8 @@ properties:
   sets:
   - standard
   - extended
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 112
 - name: products
@@ -571,7 +538,8 @@ properties:
   sets:
   - standard
   - array
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 201
 - name: productsIds
@@ -603,7 +571,8 @@ properties:
   sets:
   - array
   - system
-  - post
+  prompt:
+  - array_enricher
   metadata:
     order: 219
 - name: productCategories
@@ -619,7 +588,8 @@ properties:
   sets:
   - standard
   - array
-  - post
+  prompt:
+  - array_enricher
   metadata:
     order: 202
 - name: productPricing
@@ -635,7 +605,8 @@ properties:
   sets:
   - standard
   - array
-  - post
+  prompt:
+  - array_enricher
   metadata:
     order: 203
 - name: productFeatures
@@ -651,7 +622,8 @@ properties:
   sets:
   - standard
   - array
-  - post
+  prompt:
+  - array_enricher
   metadata:
     order: 204
 - name: productMaturityLLM
@@ -662,9 +634,10 @@ properties:
   tags:
   - LLM
   sets:
-  - prompt
   - extended
   - standard
+  prompt:
+  - main
   metadata:
     order: 136
 - name: productMaturityCIT
@@ -677,8 +650,8 @@ properties:
   tags:
   - CIT
   - provenance
-  sets:
-  - prompt
+  prompt:
+  - main
   metadata:
     source_llm: productMaturityLLM
     order: 137
@@ -727,8 +700,9 @@ properties:
   - research
   sets:
   - standard
-  - EnumCat
   - extended
+  prompt:
+  - cat_classifier
   metadata:
     source_llm: productMaturityLLM
     order: 135
@@ -740,9 +714,10 @@ properties:
   tags:
   - LLM
   sets:
-  - prompt
   - extended
   - standard
+  prompt:
+  - main
   metadata:
     order: 138
 - name: goToMarketCIT
@@ -755,8 +730,8 @@ properties:
   tags:
   - CIT
   - provenance
-  sets:
-  - prompt
+  prompt:
+  - main
   metadata:
     source_llm: goToMarketLLM
     order: 139
@@ -800,7 +775,8 @@ properties:
   - research
   sets:
   - standard
-  - EnumCat
+  prompt:
+  - cat_classifier
   metadata:
     source_llm: goToMarketLLM
     order: 137
@@ -845,7 +821,8 @@ properties:
   - research
   sets:
   - standard
-  - EnumCat
+  prompt:
+  - cat_classifier
   metadata:
     source_llm: goToMarketLLM
     order: 138
@@ -877,7 +854,8 @@ properties:
       skip: true
   sets:
   - system
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 911
 - name: analysisConfidence
@@ -907,7 +885,8 @@ properties:
       skip: true
   sets:
   - system
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 901
 - name: sourceQuality
@@ -933,7 +912,8 @@ properties:
       skip: true
   sets:
   - system
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 902
 - name: page_facts_count
@@ -956,7 +936,8 @@ properties:
       skip: true
   sets:
   - system
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 904
 - name: researcher_model_id
@@ -983,8 +964,9 @@ properties:
   description: Overall product portfolio strength score (1-10)
   sets:
   - standard
-  - prompt
   - extended
+  prompt:
+  - main
   tags:
   - score
   metadata:
@@ -994,8 +976,8 @@ properties:
   - number[]
   description: 'Market fit score for {subject} (1-10). Assess product-market alignment based on target audience clarity and value proposition strength. Use 0 if insufficient data.'
   parallel_to: products
-  sets:
-  - post
+  prompt:
+  - array_enricher
   tags:
   - score
   metadata:
@@ -1005,8 +987,8 @@ properties:
   - number[]
   description: 'Product maturity/adoption score for {subject} (1-10). Assess lifecycle stage and adoption signals. Use 0 if insufficient data.'
   parallel_to: products
-  sets:
-  - post
+  prompt:
+  - array_enricher
   tags:
   - score
   metadata:
@@ -1016,8 +998,8 @@ properties:
   - number[]
   description: 'Revenue contribution score for {subject} (1-10). Estimate based on pricing visibility, customer traction signals, and product prominence. Use 0 if insufficient data.'
   parallel_to: products
-  sets:
-  - post
+  prompt:
+  - array_enricher
   tags:
   - score
   metadata:

--- a/schemas/Research_risk_schema.yaml
+++ b/schemas/Research_risk_schema.yaml
@@ -135,9 +135,10 @@ properties:
   tags:
   - LLM
   sets:
-  - prompt
   - extended
   - standard
+  prompt:
+  - main
   metadata:
     order: 122
 - name: securityPostureCIT
@@ -150,8 +151,8 @@ properties:
   tags:
   - CIT
   - provenance
-  sets:
-  - prompt
+  prompt:
+  - main
   metadata:
     source_llm: securityPostureLLM
     order: 123
@@ -165,7 +166,8 @@ properties:
   - security
   sets:
   - extended
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 123
 - name: securityCertifications
@@ -180,7 +182,8 @@ properties:
   - security
   sets:
   - array
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 201
 - name: securityDocumentation
@@ -193,7 +196,8 @@ properties:
   - security
   sets:
   - extended
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 124
 - name: expectedSecurityPosture
@@ -206,7 +210,8 @@ properties:
   - security
   sets:
   - extended
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 125
 - name: securityGap
@@ -219,7 +224,8 @@ properties:
   - security
   sets:
   - extended
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 126
 - name: complianceCertificationLLM
@@ -230,9 +236,10 @@ properties:
   tags:
   - LLM
   sets:
-  - prompt
   - extended
   - standard
+  prompt:
+  - main
   metadata:
     order: 132
 - name: complianceCertificationCIT
@@ -245,8 +252,8 @@ properties:
   tags:
   - CIT
   - provenance
-  sets:
-  - prompt
+  prompt:
+  - main
   metadata:
     source_llm: complianceCertificationLLM
     order: 133
@@ -262,7 +269,8 @@ properties:
   - research
   sets:
   - array
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 202
 - name: privacyPolicy
@@ -275,7 +283,8 @@ properties:
   - research
   sets:
   - extended
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 133
 - name: expectedCompliance
@@ -288,7 +297,8 @@ properties:
   - research
   sets:
   - extended
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 134
 - name: complianceGap
@@ -301,7 +311,8 @@ properties:
   - research
   sets:
   - extended
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 135
 - name: regulatoryEnvironmentLLM
@@ -312,9 +323,10 @@ properties:
   tags:
   - LLM
   sets:
-  - prompt
   - extended
   - standard
+  prompt:
+  - main
   metadata:
     order: 142
 - name: regulatoryEnvironmentCIT
@@ -327,8 +339,8 @@ properties:
   tags:
   - CIT
   - provenance
-  sets:
-  - prompt
+  prompt:
+  - main
   metadata:
     source_llm: regulatoryEnvironmentLLM
     order: 143
@@ -342,7 +354,8 @@ properties:
   - research
   sets:
   - array
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 203
 - name: regulatoryBurden
@@ -355,7 +368,8 @@ properties:
   - research
   sets:
   - extended
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 143
 - name: industryRiskFactors
@@ -369,7 +383,8 @@ properties:
   - risk
   sets:
   - array
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 204
 - name: marketRiskFactors
@@ -382,7 +397,8 @@ properties:
   - risk
   sets:
   - array
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 205
 - name: riskProfile
@@ -395,7 +411,8 @@ properties:
   - risk
   sets:
   - extended
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 111
 - name: securityPostureCat
@@ -417,7 +434,8 @@ properties:
   - security
   sets:
   - standard
-  - EnumCat
+  prompt:
+  - cat_classifier
   metadata:
     order: 121
 - name: complianceCertificationCat
@@ -431,7 +449,8 @@ properties:
   - compliance
   sets:
   - standard
-  - VecCat
+  prompt:
+  - vec_classifier
   metadata:
     order: 131
 - name: regulatoryEnvironmentCat
@@ -451,7 +470,8 @@ properties:
   - regulatory
   sets:
   - standard
-  - EnumCat
+  prompt:
+  - cat_classifier
   metadata:
     order: 141
 - name: processedDate
@@ -468,7 +488,8 @@ properties:
   description: Review flag for human validation (none/for_review/needs_verification)
   sets:
   - system
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 910
 - name: analysisConfidence
@@ -477,7 +498,8 @@ properties:
   description: Confidence level of analysis (high/medium/low/inferred/web_verified)
   sets:
   - system
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 901
 - name: sourceQuality
@@ -503,7 +525,8 @@ properties:
       skip: true
   sets:
   - system
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 902
 - name: page_facts_count
@@ -526,7 +549,8 @@ properties:
       skip: true
   sets:
   - system
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 904
 - name: researcher_model_id

--- a/schemas/Research_social_schema.yaml
+++ b/schemas/Research_social_schema.yaml
@@ -190,7 +190,8 @@ properties:
   - research
   sets:
   - extended
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 112
 - name: socialPlatforms
@@ -203,8 +204,9 @@ properties:
   - research
   sets:
   - array
-  - prompt
   - extended
+  prompt:
+  - main
   metadata:
     order: 201
 - name: socialEngagementScore
@@ -214,8 +216,8 @@ properties:
   tags:
   - research
   - score
-  sets:
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 113
 - name: hasSocialAuth
@@ -224,8 +226,8 @@ properties:
   description: Has social authentication features
   tags:
   - research
-  sets:
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 114
 - name: hasSocialSharing
@@ -236,7 +238,8 @@ properties:
   - research
   sets:
   - extended
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 115
 - name: hasCommunityFeatures
@@ -247,7 +250,8 @@ properties:
   - research
   sets:
   - extended
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 116
 - name: socialPresenceTier
@@ -258,7 +262,8 @@ properties:
   - research
   sets:
   - extended
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 117
 - name: contentThemes
@@ -271,7 +276,8 @@ properties:
   - research
   sets:
   - array
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 202
 - name: socialProofIndicators
@@ -282,7 +288,8 @@ properties:
   - research
   sets:
   - array
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 203
 - name: platformPresenceLLM
@@ -294,9 +301,10 @@ properties:
   - LLM
   - score
   sets:
-  - prompt
   - extended
   - standard
+  prompt:
+  - main
   metadata:
     order: 122
 - name: platformPresenceCIT
@@ -309,8 +317,8 @@ properties:
   tags:
   - CIT
   - provenance
-  sets:
-  - prompt
+  prompt:
+  - main
   metadata:
     source_llm: platformPresenceLLM
     order: 123
@@ -323,9 +331,10 @@ properties:
   - LLM
   - research
   sets:
-  - prompt
   - extended
   - standard
+  prompt:
+  - main
   metadata:
     order: 124
 - name: socialContentCIT
@@ -338,8 +347,8 @@ properties:
   tags:
   - CIT
   - provenance
-  sets:
-  - prompt
+  prompt:
+  - main
   metadata:
     source_llm: socialContentLLM
     order: 125
@@ -351,9 +360,10 @@ properties:
   tags:
   - LLM
   sets:
-  - prompt
   - extended
   - standard
+  prompt:
+  - main
   metadata:
     order: 126
 - name: communityEngagementCIT
@@ -366,8 +376,8 @@ properties:
   tags:
   - CIT
   - provenance
-  sets:
-  - prompt
+  prompt:
+  - main
   metadata:
     source_llm: communityEngagementLLM
     order: 127
@@ -383,7 +393,8 @@ properties:
   - research
   sets:
   - extended
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 111
 - name: platformPresenceCat
@@ -405,8 +416,9 @@ properties:
   - social
   sets:
   - standard
-  - EnumCat
   - extended
+  prompt:
+  - cat_classifier
   metadata:
     order: 121
 - name: socialContentCat
@@ -431,7 +443,8 @@ properties:
   - research
   sets:
   - standard
-  - EnumCat
+  prompt:
+  - cat_classifier
   metadata:
     order: 123
 - name: communityEngagementCat
@@ -454,7 +467,8 @@ properties:
   - social
   sets:
   - standard
-  - EnumCat
+  prompt:
+  - cat_classifier
   metadata:
     order: 125
 - name: processedDate
@@ -471,7 +485,8 @@ properties:
   description: Review flag for human validation (none/for_review/needs_verification)
   sets:
   - system
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 910
 - name: analysisConfidence
@@ -480,7 +495,8 @@ properties:
   description: Confidence level of analysis (high/medium/low/inferred/web_verified)
   sets:
   - system
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 901
 - name: sourceQuality
@@ -506,7 +522,8 @@ properties:
       skip: true
   sets:
   - system
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 902
 - name: page_facts_count
@@ -529,7 +546,8 @@ properties:
       skip: true
   sets:
   - system
-  - prompt
+  prompt:
+  - main
   metadata:
     order: 904
 - name: researcher_model_id

--- a/schemas/domain_schema.yaml
+++ b/schemas/domain_schema.yaml
@@ -162,7 +162,8 @@ properties:
   tokenization: word
   sets:
   - system
-  - prompt
+  prompt:
+  - main
   tags:
   - identity
   - metadata
@@ -176,7 +177,8 @@ properties:
   tokenization: word
   sets:
   - system
-  - prompt
+  prompt:
+  - main
   tags:
   - content
   - metadata
@@ -189,7 +191,8 @@ properties:
   indexFilterable: true
   sets:
   - extended
-  - prompt
+  prompt:
+  - main
   tags:
   - identity
   - metadata
@@ -202,7 +205,8 @@ properties:
   tokenization: word
   sets:
   - extended
-  - prompt
+  prompt:
+  - main
   tags:
   - identity
   - location
@@ -218,7 +222,8 @@ properties:
   tokenization: field
   sets:
   - extended
-  - prompt
+  prompt:
+  - main
   tags:
   - contact
   - physical
@@ -231,7 +236,8 @@ properties:
   tokenization: field
   sets:
   - extended
-  - prompt
+  prompt:
+  - main
   tags:
   - contact
   - physical
@@ -244,7 +250,8 @@ properties:
   tokenization: word
   sets:
   - extended
-  - prompt
+  prompt:
+  - main
   tags:
   - location
   - physical
@@ -257,7 +264,8 @@ properties:
   tokenization: field
   sets:
   - extended
-  - prompt
+  prompt:
+  - main
   tags:
   - location
   - physical
@@ -270,7 +278,8 @@ properties:
   tokenization: field
   sets:
   - extended
-  - prompt
+  prompt:
+  - main
   tags:
   - location
   - physical
@@ -283,7 +292,8 @@ properties:
   tokenization: field
   sets:
   - extended
-  - prompt
+  prompt:
+  - main
   tags:
   - location
   - physical
@@ -296,7 +306,8 @@ properties:
   tokenization: field
   sets:
   - extended
-  - prompt
+  prompt:
+  - main
   tags:
   - location
   - physical
@@ -307,7 +318,8 @@ properties:
   description: Geographic coordinates (latitude, longitude)
   sets:
   - extended
-  - prompt
+  prompt:
+  - main
   tags:
   - location
   - physical
@@ -1134,7 +1146,8 @@ properties:
   sets:
   - status_update
   - system
-  - prompt
+  prompt:
+  - main
   tags:
   - pipeline
   - processing
@@ -1499,7 +1512,8 @@ properties:
   tokenization: field
   sets:
   - system
-  - prompt
+  prompt:
+  - main
   tags:
   - identity
   - financial


### PR DESCRIPTION
## Summary

- Add `prompt` property to all schema fields across 11 schemas, mapping each field to the prompt type that writes it (`main`, `array_enricher`, `array_domain_finder`, `cat_classifier`, `vec_classifier`)
- Remove unused VecCat metadata fields (`useCaseSimilarities`, etc.) from customer and product schemas
- Remove deprecated `uses_execution_artifacts`, `priority`, `mode` from post-tool prompty configs
- Reframe `post_execution_tools` comments in all 5 researcher_ai YAMLs as "prompt chain" definitions

## Cross-repo

- **pom-core** PR #888: model + code changes for prompt property support
- **pom-docs** branch `feat/pomflow-prompt-chain-docs`: architecture doc updates

## Test plan

- [x] YAML validation hooks pass
- [ ] Schema fields correctly route to prompt types via `prompt` property
- [ ] Existing researcher flows produce identical results


Made with [Cursor](https://cursor.com)