### PR TITLE
fix: add fallback values to all array_enricher field descriptions

### DIFF
--- a/schemas/Research_competitor_schema.yaml
+++ b/schemas/Research_competitor_schema.yaml
@@ -258,7 +258,7 @@ properties:
 - name: competitorPositioning
   dataType:
   - text[]
-  description: 'Concise market positioning for {subject}. Examples: "Market Leader", "Strong Challenger", "Niche Specialist", "Emerging Player". No citations or URLs; use evidence/CIT fields for sources.'
+  description: 'Concise market positioning for {subject}. Examples: "Market Leader", "Strong Challenger", "Niche Specialist", "Emerging Player". No citations or URLs; use evidence/CIT fields for sources. Use "Unknown" if insufficient data.'
   parallel_to: keyCompetitors
   tags:
   - research
@@ -288,7 +288,7 @@ properties:
 - name: competitorTargetMarket
   dataType:
   - text[]
-  description: 'Concise target market for {subject}. Examples: "Enterprise", "SMB", "Mid-market", "Startups", "Healthcare vertical". No citations or URLs; use evidence/CIT fields for sources.'
+  description: 'Concise target market for {subject}. Examples: "Enterprise", "SMB", "Mid-market", "Startups", "Healthcare vertical". No citations or URLs; use evidence/CIT fields for sources. Use "Unknown" if insufficient data.'
   parallel_to: keyCompetitors
   tags:
   - research
@@ -303,7 +303,7 @@ properties:
 - name: innovationScore
   dataType:
   - number[]
-  description: Each competitor's innovation capability (1-10)
+  description: Each competitor's innovation capability (1-10). Use 0 if insufficient data.
   parallel_to: keyCompetitors
   sets:
   - array
@@ -318,7 +318,7 @@ properties:
 - name: keyCompetitorEvidence
   dataType:
   - text[]
-  description: 'Evidence/context snippets for {subject} used to justify competitive positioning, pricing, and feature claims. Store source text or notes for this subject; keep summaries in the LLM fields.'
+  description: 'Evidence/context snippets for {subject} used to justify competitive positioning, pricing, and feature claims. Store source text or notes for this subject; keep summaries in the LLM fields. Use "No specific evidence available" if none found.'
   parallel_to: keyCompetitors
   moduleConfig:
     text2vec-weaviate:
@@ -336,7 +336,7 @@ properties:
 - name: marketStrengthScore
   dataType:
   - number[]
-  description: Each competitor's market strength (1-10)
+  description: Each competitor's market strength (1-10). Use 0 if insufficient data.
   parallel_to: keyCompetitors
   sets:
   - array
@@ -351,7 +351,7 @@ properties:
 - name: threatLevelScore
   dataType:
   - number[]
-  description: Competitive threat level per competitor (1-10)
+  description: Competitive threat level per competitor (1-10). Use 0 if insufficient data.
   parallel_to: keyCompetitors
   sets:
   - array

--- a/schemas/Research_customer_schema.yaml
+++ b/schemas/Research_customer_schema.yaml
@@ -221,7 +221,7 @@ properties:
 - name: keyCustomerEvidence
   dataType:
   - text[]
-  description: 'Brief description of {subject}: what type of organization, what industry/sector, what they do. Used for classification context.'
+  description: 'Brief description of {subject}: what type of organization, what industry/sector, what they do. Used for classification context. Use "No description available" if unknown.'
   parallel_to: keyCustomers
   moduleConfig:
     text2vec-weaviate:
@@ -729,7 +729,7 @@ properties:
   dataType:
   - text[]
   description: |
-    Industry segment for each key customer: specific vertical, niche, or specialization.
+    Industry segment for each key customer: specific vertical, niche, or specialization. Use "Unknown" if insufficient data.
   parallel_to: keyCustomers
   moduleConfig:
     text2vec-weaviate:
@@ -748,7 +748,7 @@ properties:
 - name: keyCustomerIndustrySegmentCIT
   dataType:
   - text[]
-  description: Source URLs supporting the keyCustomerIndustrySegmentLLM analysis. Cite page URLs from pageData or web_search.
+  description: Source URLs supporting the keyCustomerIndustrySegmentLLM analysis. Cite page URLs from pageData or web_search. Use empty string if no sources available.
   moduleConfig:
     text2vec-weaviate:
       skip: true
@@ -938,7 +938,7 @@ properties:
 - name: accountSizeScore
   dataType:
   - number[]
-  description: Account size/revenue potential score per key customer (1-10)
+  description: Account size/revenue potential score per key customer (1-10). Use 0 if insufficient data.
   parallel_to: keyCustomers
   prompt:
   - array_enricher
@@ -949,7 +949,7 @@ properties:
 - name: strategicValueScore
   dataType:
   - number[]
-  description: Strategic value score per key customer (1-10)
+  description: Strategic value score per key customer (1-10). Use 0 if insufficient data.
   parallel_to: keyCustomers
   prompt:
   - array_enricher
@@ -960,7 +960,7 @@ properties:
 - name: expansionPotentialScore
   dataType:
   - number[]
-  description: Expansion potential score per key customer (1-10)
+  description: Expansion potential score per key customer (1-10). Use 0 if insufficient data.
   parallel_to: keyCustomers
   prompt:
   - array_enricher

--- a/schemas/Research_financial_schema.yaml
+++ b/schemas/Research_financial_schema.yaml
@@ -232,7 +232,7 @@ properties:
 - name: keyFinancialMetrics
   dataType:
   - text[]
-  description: Key Financial Metrics - evidence extracted from sources
+  description: Key Financial Metrics - evidence extracted from sources. Use "No financial metrics available" if none found.
   tags:
   - financial
   - metrics

--- a/schemas/Research_leadership_schema.yaml
+++ b/schemas/Research_leadership_schema.yaml
@@ -351,7 +351,7 @@ properties:
   dataType:
   - text[]
   description: Evidence/context found for each keyExecutive from page facts search. Stores
-    the factual basis for classifications and extracted values.
+    the factual basis for classifications and extracted values. Use "No specific evidence available" if none found.
   parallel_to: keyExecutives
   moduleConfig:
     text2vec-weaviate:
@@ -430,7 +430,7 @@ properties:
   - extended
   - standard
   prompt:
-  - array_enricher
+  - array_domain_finder
   metadata:
     order: 205
 - name: leadershipStyleLLM

--- a/schemas/Research_partner_schema.yaml
+++ b/schemas/Research_partner_schema.yaml
@@ -176,7 +176,7 @@ properties:
   dataType:
   - text[]
   description: Evidence/context found for each keyPartner from page facts search. Stores the
-    factual basis for classifications and extracted values.
+    factual basis for classifications and extracted values. Use "No specific evidence available" if none found.
   parallel_to: keyPartners
   moduleConfig:
     text2vec-weaviate:

--- a/schemas/Research_product_schema.yaml
+++ b/schemas/Research_product_schema.yaml
@@ -559,7 +559,7 @@ properties:
   dataType:
   - text[]
   description: Evidence/context found for each product from page facts search. Stores the factual
-    basis for classifications and extracted values.
+    basis for classifications and extracted values. Use "No specific evidence available" if none found.
   parallel_to: products
   moduleConfig:
     text2vec-weaviate:
@@ -626,6 +626,24 @@ properties:
   - array_enricher
   metadata:
     order: 204
+- name: productURL
+  dataType:
+  - text[]
+  description: 'Primary website or landing page URL for {subject}. Find the product homepage, documentation site, or main marketing page. Example: https://www.example.com/product-name. Use "Not disclosed" if unknown.'
+  parallel_to: products
+  moduleConfig:
+    text2vec-weaviate:
+      skip: true
+  tags:
+  - research
+  - web
+  sets:
+  - array
+  - standard
+  prompt:
+  - array_domain_finder
+  metadata:
+    order: 205
 - name: productMaturityLLM
   dataType:
   - text


### PR DESCRIPTION
## Summary
- Added fallback values to 16 `array_enricher` field descriptions across 6 schemas that were missing them
- The prompty instructs "use fallback values from descriptions, never null" but these fields had no fallback defined, causing the LLM to return empty/null
- Also includes leadership schema `array_domain_finder` fix and product schema `productURL` field

## Schemas updated
- Research_competitor (7 fields)
- Research_customer (6 fields) 
- Research_financial (1 field)
- Research_product (1 field + productURL)
- Research_leadership (1 field + domain finder fix)
- Research_partner (1 field)

## Test plan
- [ ] Run competitor researcher and verify "Parallel enrichment incomplete" warnings are reduced
- [ ] Verify evidence fields return "No specific evidence available" instead of null

Made with [Cursor](https://cursor.com)