### PR TITLE
feat: add parallel_array_enricher to entity researcher post-execution tools

### DIFF
--- a/prompts/entity/entity_researcher.prompty
+++ b/prompts/entity/entity_researcher.prompty
@@ -119,8 +119,7 @@ processing_config:
   source_collection: Domain
   target_collections:
     - Research_industry
-  required_processing_flags:
-    researcher_processing_status: null
+  required_processing_flags: {}
   max_turns: 15  # Multi-turn for tool calling conversations
   iteration_parameter: researcher_id
   iteration_values: "TENANT_GROUP_RESEARCHERS"
@@ -130,6 +129,7 @@ processing_config:
 
 # 🔧 POST-EXECUTION TOOLS
 post_execution_tools:
+  - parallel_array_enricher
   - enum_cat
 ---
 {# ══════════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary
- Add `parallel_array_enricher` as first post-execution tool in entity researcher prompt
- Simplify `required_processing_flags` to empty dict

## Test plan
- [x] Prompt template parses correctly

Made with [Cursor](https://cursor.com)