### PR TITLE
feat: add domain unreachable fields and playwright defaults

### DIFF
--- a/schemas/domain_schema.yaml
+++ b/schemas/domain_schema.yaml
@@ -1042,6 +1042,54 @@ properties:
   tags:
   - filtering
 
+- name: is_unreachable
+  dataType:
+  - boolean
+  description: Whether the domain is marked unreachable after repeated failures
+  indexFilterable: true
+  sets:
+  - system
+  - status_update
+  tags:
+  - filtering
+  - processing
+
+- name: unreachable_attempts
+  dataType:
+  - int
+  description: Count of runs that hit the domain error threshold
+  indexFilterable: true
+  sets:
+  - system
+  - status_update
+  tags:
+  - processing
+  - metrics
+
+- name: unreachable_reason
+  dataType:
+  - text
+  description: Last error category that triggered an unreachable attempt
+  indexFilterable: true
+  tokenization: field
+  sets:
+  - system
+  - status_update
+  tags:
+  - processing
+  - errors
+
+- name: unreachable_at
+  dataType:
+  - date
+  description: Timestamp when the domain was marked unreachable
+  sets:
+  - system
+  - status_update
+  tags:
+  - temporal
+  - processing
+
 - name: enrichment_attempts
   dataType:
   - int

--- a/shared-config.env
+++ b/shared-config.env
@@ -326,6 +326,22 @@ MAC_BROWSER_POOL_URL=http://mac-browser-pool:4100
 SPARK_BROWSER_POOL_URL=http://spark-browser-pool:4100
 
 # =============================================================================
+# PLAYWRIGHT POOL (pom-core) - Spark defaults
+# =============================================================================
+# Keep in sync with Spark browser pool capacity
+PLAYWRIGHT_POOL_SIZE=500
+# Recycle contexts after N page loads to cap memory growth
+PLAYWRIGHT_CONTEXT_MAX_USES=100
+# Zombie detection threshold (seconds)
+PLAYWRIGHT_ZOMBIE_TIMEOUT=300
+# Zombie reaper interval (seconds)
+PLAYWRIGHT_ZOMBIE_REAPER_INTERVAL=60
+# Stream safety: break if no output for this long (seconds)
+STREAM_IDLE_TIMEOUT=600
+# Heartbeat for liveness + redis metrics (seconds)
+STREAM_HEARTBEAT_INTERVAL=60
+
+# =============================================================================
 # WEAVIATE TUNING
 # =============================================================================
 


### PR DESCRIPTION
## Summary
- add domain unreachable fields to domain schema
- add Playwright pool defaults for Spark in shared config

## Test plan
- Not run (config/schema change)

Made with [Cursor](https://cursor.com)