### PR TITLE
fix: update credential comments to reference configs/secrets.env

### DIFF
--- a/.pom_config_pkg/shared-config.env
+++ b/.pom_config_pkg/shared-config.env
@@ -5,7 +5,7 @@
 # This file is part of pom-config and is shared across all Pom ecosystem apps.
 # Update via: ./scripts/pom_config.sh update
 #
-# For secrets (API keys, passwords), use ~/.shared-credentials.env instead.
+# For secrets (API keys, passwords), use PomSpark/configs/secrets.env.
 #
 # See: pom-docs/docs/infrastructure/SHARED_CONFIG_GUIDE.md
 #
@@ -202,7 +202,7 @@ SPARK_TRANSFORMERS_PROXY_URL=http://spark-proxy.digitalocean.com:8090
 REDIS_URL=redis://mac-redis:6379
 
 # =============================================================================
-# SUPABASE CONFIGURATION (URLs only - keys in shared-credentials.env)
+# SUPABASE CONFIGURATION (URLs only - keys in configs/secrets.env)
 # =============================================================================
 
 SUPABASE_URL=https://mhgpujddrrxwlfoyegxg.supabase.co
@@ -217,7 +217,7 @@ VITE_WS_URL=ws://localhost:8001
 VITE_BACKEND_URL=http://localhost:8001
 FRONTEND_URL=http://localhost:5174
 
-# Supabase frontend (anon key in shared-credentials.env)
+# Supabase frontend (anon key in configs/secrets.env)
 VITE_SUPABASE_URL=https://mhgpujddrrxwlfoyegxg.supabase.co
 
 # =============================================================================
@@ -234,7 +234,7 @@ BACKUP_BUCKET=pomothy-weaviate-backups-gcs
 VAST_ENDPOINT_NAME=vLLM-Qwen3-8B
 
 # =============================================================================
-# OMADA CONTROLLER (URLs only - credentials in shared-credentials.env)
+# OMADA CONTROLLER (URLs only - credentials in configs/secrets.env)
 # =============================================================================
 
 OMADA_CONTROLLER_URL=https://192.168.0.229

--- a/shared-config.env
+++ b/shared-config.env
@@ -5,7 +5,7 @@
 # This file is part of pom-config and is shared across all Pom ecosystem apps.
 # Update via: ./scripts/pom_config.sh update
 #
-# For secrets (API keys, passwords), use ~/.shared-credentials.env instead.
+# For secrets (API keys, passwords), use PomSpark/configs/secrets.env.
 #
 # See: pom-docs/docs/infrastructure/SHARED_CONFIG_GUIDE.md
 #
@@ -209,7 +209,7 @@ SETUPTOOLS_SCM_PRETEND_VERSION=5.1.88
 REDIS_URL=redis://spark-redis:6379
 
 # =============================================================================
-# SUPABASE CONFIGURATION (URLs only - keys in shared-credentials.env)
+# SUPABASE CONFIGURATION (URLs only - keys in configs/secrets.env)
 # =============================================================================
 
 SUPABASE_URL=https://mhgpujddrrxwlfoyegxg.supabase.co
@@ -224,7 +224,7 @@ VITE_WS_URL=ws://localhost:8001
 VITE_BACKEND_URL=http://localhost:8001
 FRONTEND_URL=http://localhost:5174
 
-# Supabase frontend (anon key in shared-credentials.env)
+# Supabase frontend (anon key in configs/secrets.env)
 VITE_SUPABASE_URL=https://mhgpujddrrxwlfoyegxg.supabase.co
 
 # =============================================================================
@@ -241,7 +241,7 @@ BACKUP_BUCKET=pomothy-weaviate-backups-gcs
 VAST_ENDPOINT_NAME=vLLM-Qwen3-8B
 
 # =============================================================================
-# OMADA CONTROLLER (URLs only - credentials in shared-credentials.env)
+# OMADA CONTROLLER (URLs only - credentials in configs/secrets.env)
 # =============================================================================
 
 OMADA_CONTROLLER_URL=https://192.168.0.229


### PR DESCRIPTION
## Summary

- Updated 4 comments in shared-config.env that referenced the deprecated ~/.shared-credentials.env to point to the canonical PomSpark/configs/secrets.env
- Updated matching copy in .pom_config_pkg/shared-config.env

## Test plan

- [x] Zero references to `shared-credentials.env` remain in pom-config (`rg shared-credentials.env` returns nothing)
- [x] Comments correctly point to `configs/secrets.env`

## Related

- PomSpark PR for full secrets loading cleanup
- pom-core#900, pom-docs#45

Made with [Cursor](https://cursor.com)