### PR TITLE
feat: add entityId to all Research schemas

### DIFF
--- a/schemas/Research_customer_schema.yaml
+++ b/schemas/Research_customer_schema.yaml
@@ -86,6 +86,21 @@ properties:
   - main
   metadata:
     order: 111
+- name: entityId
+  dataType:
+  - text
+  description: Unique entity identifier from source record
+  moduleConfig:
+    text2vec-weaviate:
+      skip: true
+  sets:
+  - system
+  - identifier
+  - extended
+  tags:
+  - identity
+  metadata:
+    order: 905
 - name: entityName
   dataType:
   - text

--- a/schemas/Research_financial_schema.yaml
+++ b/schemas/Research_financial_schema.yaml
@@ -96,6 +96,21 @@ properties:
   - summary
   metadata:
     order: 101
+- name: entityId
+  dataType:
+  - text
+  description: Unique entity identifier from source record
+  moduleConfig:
+    text2vec-weaviate:
+      skip: true
+  sets:
+  - system
+  - identifier
+  - extended
+  tags:
+  - identity
+  metadata:
+    order: 905
 - name: entityName
   dataType:
   - text

--- a/schemas/Research_journalist_schema.yaml
+++ b/schemas/Research_journalist_schema.yaml
@@ -97,6 +97,21 @@ properties:
   - summary
   metadata:
     order: 101
+- name: entityId
+  dataType:
+  - text
+  description: Unique entity identifier from source record
+  moduleConfig:
+    text2vec-weaviate:
+      skip: true
+  sets:
+  - system
+  - identifier
+  - extended
+  tags:
+  - identity
+  metadata:
+    order: 905
 - name: entityName
   dataType:
   - text

--- a/schemas/Research_leadership_schema.yaml
+++ b/schemas/Research_leadership_schema.yaml
@@ -88,6 +88,21 @@ properties:
   - summary
   metadata:
     order: 101
+- name: entityId
+  dataType:
+  - text
+  description: Unique entity identifier from source record
+  moduleConfig:
+    text2vec-weaviate:
+      skip: true
+  sets:
+  - system
+  - identifier
+  - extended
+  tags:
+  - identity
+  metadata:
+    order: 905
 - name: entityName
   dataType:
   - text

--- a/schemas/Research_partner_schema.yaml
+++ b/schemas/Research_partner_schema.yaml
@@ -86,6 +86,21 @@ properties:
   - summary
   metadata:
     order: 101
+- name: entityId
+  dataType:
+  - text
+  description: Unique entity identifier from source record
+  moduleConfig:
+    text2vec-weaviate:
+      skip: true
+  sets:
+  - system
+  - identifier
+  - extended
+  tags:
+  - identity
+  metadata:
+    order: 905
 - name: entityName
   dataType:
   - text

--- a/schemas/Research_product_schema.yaml
+++ b/schemas/Research_product_schema.yaml
@@ -174,6 +174,21 @@ properties:
   - summary
   metadata:
     order: 101
+- name: entityId
+  dataType:
+  - text
+  description: Unique entity identifier from source record
+  moduleConfig:
+    text2vec-weaviate:
+      skip: true
+  sets:
+  - system
+  - identifier
+  - extended
+  tags:
+  - identity
+  metadata:
+    order: 905
 - name: entityName
   dataType:
   - text

--- a/schemas/Research_risk_schema.yaml
+++ b/schemas/Research_risk_schema.yaml
@@ -102,6 +102,21 @@ properties:
   - system
   metadata:
     order: 915
+- name: entityId
+  dataType:
+  - text
+  description: Unique entity identifier from source record
+  moduleConfig:
+    text2vec-weaviate:
+      skip: true
+  sets:
+  - system
+  - identifier
+  - extended
+  tags:
+  - identity
+  metadata:
+    order: 905
 - name: entityName
   dataType:
   - text

--- a/schemas/Research_social_schema.yaml
+++ b/schemas/Research_social_schema.yaml
@@ -157,6 +157,21 @@ properties:
   - summary
   metadata:
     order: 101
+- name: entityId
+  dataType:
+  - text
+  description: Unique entity identifier from source record
+  moduleConfig:
+    text2vec-weaviate:
+      skip: true
+  sets:
+  - system
+  - identifier
+  - extended
+  tags:
+  - identity
+  metadata:
+    order: 905
 - name: entityName
   dataType:
   - text


### PR DESCRIPTION
## Summary
- Added `entityId` property to 8 Research schemas missing it (fixes #914 in pom-core)
- Fields: `dataType: text`, `order: 905`, system/identifier/extended sets

## Schemas Updated
Research_customer, Research_financial, Research_journalist, Research_leadership, Research_partner, Research_product, Research_risk, Research_social

## Test plan
- [ ] Verify all 11 Research schemas now have entityId
- [ ] Schema sync doesn't break existing data

Made with [Cursor](https://cursor.com)