### PR TITLE
fix: post-merge hook uses pom-core venv for validation

### DIFF
--- a/.githooks/post-merge
+++ b/.githooks/post-merge
@@ -1,18 +1,35 @@
 #!/usr/bin/env bash
-set -euo pipefail
+# pom-config post-merge hook: validate configs when YAML/prompty files change.
+# Requires pom-core venv for pyyaml + pom_core model imports.
 
 echo "[pom-config] post-merge hook: repository updated."
 
-if git diff --name-only HEAD@{1}..HEAD | grep -E '\.ya?ml$|\.prompty$|\.env$|^OWNERSHIP\.yaml$' >/dev/null; then
-  echo "[pom-config] Detected config or ownership changes; running validations."
-  if command -v python3 >/dev/null 2>&1; then
-    python3 scripts/validate_all_configs.py
-    python3 scripts/validate-ownership.py
-  else
-    echo "[pom-config] python3 not found; please run:"
-    echo "  python3 scripts/validate_all_configs.py"
-    echo "  python3 scripts/validate-ownership.py"
-  fi
-else
+if ! git diff --name-only HEAD@{1}..HEAD | grep -qE '\.ya?ml$|\.prompty$|\.env$|^OWNERSHIP\.yaml$'; then
   echo "[pom-config] No config/ownership changes detected."
+  exit 0
 fi
+
+echo "[pom-config] Detected config or ownership changes; running validations."
+
+# Resolve Python: prefer pom-core venv (has pyyaml + pom_core models)
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+POM_CORE_VENV="${REPO_ROOT}/../pom-core/venv/bin/python"
+
+if [ -x "$POM_CORE_VENV" ]; then
+  PYTHON="$POM_CORE_VENV"
+elif command -v python3 >/dev/null 2>&1; then
+  PYTHON="python3"
+else
+  echo "[pom-config] ⚠️  No python3 found; skipping validation."
+  echo "  Run manually: python3 scripts/validate_all_configs.py"
+  exit 0
+fi
+
+# Run validations (non-blocking: warn on failure, don't abort merge)
+for script in scripts/validate_all_configs.py scripts/validate-ownership.py; do
+  if [ -f "$REPO_ROOT/$script" ]; then
+    if ! "$PYTHON" "$REPO_ROOT/$script"; then
+      echo "[pom-config] ⚠️  $script failed (non-blocking). Review output above."
+    fi
+  fi
+done

--- a/scripts/validate_all_configs.py
+++ b/scripts/validate_all_configs.py
@@ -1,10 +1,16 @@
 #!/usr/bin/env python3
 """Validate all pom-config YAML files against pom-core Pydantic models."""
 
+import os
 import sys
 from pathlib import Path
 
 import yaml
+
+# Set required env vars so pom_core imports without error (validation only,
+# no real connections are made).
+os.environ.setdefault("WEAVIATE_URL", "http://localhost:8080")
+os.environ.setdefault("WEAVIATE_API_KEY", "dummy-validation-key")
 
 # Add pom-core to path for model imports
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "pom-core"))


### PR DESCRIPTION
## Summary
- Post-merge hook now resolves `pom-core/venv/bin/python` which has `pyyaml` and `pom_core`
- Falls back to system `python3`, then skips gracefully if unavailable
- Validation failures are non-blocking (warn, don't abort merge)
- `validate_all_configs.py` sets `WEAVIATE_URL`/`WEAVIATE_API_KEY` defaults so pom_core imports without error during validation-only runs

## Test plan
- [x] `validate_all_configs.py` passes with pom-core venv
- [ ] `git pull` on pom-config no longer shows `ModuleNotFoundError: yaml`

Made with [Cursor](https://cursor.com)