### PR TITLE
feat: add GATEWAY_WEAVIATE env vars for gateway rate-limiting

### DIFF
--- a/shared-config.env
+++ b/shared-config.env
@@ -505,3 +505,24 @@ SPARK_TRANSFORMERS_TUNNEL_URL=https://spark-transformers.pomothy.io
 # Cloudflare tunnel names
 CLOUDFLARE_TUNNEL_SPARK=spark-services
 CLOUDFLARE_TUNNEL_SPARK_ID=6d4a4972-ec26-4ca3-9df2-59b543b1e45a
+
+# =============================================================================
+# EXTERNAL GATEWAY: WEAVIATE (#921, #922, #923, #924)
+# =============================================================================
+# Gateway rate-limiting for Weaviate operations (vector search, BM25, upserts).
+# See pom_core/config/settings/env.py for deployment-specific guidance.
+
+# Service-level defaults (all Weaviate traffic)
+GATEWAY_WEAVIATE_REQUESTS_PER_SECOND=50
+GATEWAY_WEAVIATE_MAX_CONCURRENCY=100
+
+# Per-provider overrides (#921): Spark LAN instance
+GATEWAY_WEAVIATE_SPARK_REQUESTS_PER_SECOND=100
+GATEWAY_WEAVIATE_SPARK_MAX_CONCURRENCY=50
+
+# Per-provider overrides (#921): Weaviate Cloud
+GATEWAY_WEAVIATE_CLOUD_REQUESTS_PER_SECOND=50
+GATEWAY_WEAVIATE_CLOUD_MAX_CONCURRENCY=25
+
+# Async client pool size (#922) - raise from default 10 for high-concurrency CLI
+WEAVIATE_ASYNC_POOL_SIZE=20


### PR DESCRIPTION
## Summary
- Add GATEWAY_WEAVIATE_* env vars to shared-config.env for gateway rate-limiting
- Per-provider overrides for Spark LAN (100 req/s, 50 concurrent) and Weaviate Cloud (50 req/s, 25 concurrent)
- WEAVIATE_ASYNC_POOL_SIZE=20 for high-concurrency CLI runs

## Test plan
- [ ] Verify env vars are loaded correctly by pom-core gateway

Related: afctony64/pom-core#921, afctony64/pom-core#922, afctony64/pom-core#924

Made with [Cursor](https://cursor.com)