### PR TITLE
fix: replace gateway weaviate config with factory semaphore settings

### DIFF
--- a/shared-config.env
+++ b/shared-config.env
@@ -507,22 +507,16 @@ CLOUDFLARE_TUNNEL_SPARK=spark-services
 CLOUDFLARE_TUNNEL_SPARK_ID=6d4a4972-ec26-4ca3-9df2-59b543b1e45a
 
 # =============================================================================
-# EXTERNAL GATEWAY: WEAVIATE (#921, #922, #923, #924)
+# WEAVIATE CONCURRENCY (#922, #930)
 # =============================================================================
-# Gateway rate-limiting for Weaviate operations (vector search, BM25, upserts).
-# See pom_core/config/settings/env.py for deployment-specific guidance.
+# FIX #930: Weaviate concurrency is managed by a per-instance semaphore in
+# database_factory.py, NOT by the external gateway. Weaviate has no server-side
+# rate limiter, so we must bound in-flight requests client-side.
+#
+# WEAVIATE_MAX_INFLIGHT: Max concurrent async operations per Weaviate instance.
+#   Default 16 is conservative. Tune via load testing (sweep 1, 2, 4, 8, 16, 32).
+#   Typical sweet spots: 8-16 for cloud, 16-32 for local Spark.
+WEAVIATE_MAX_INFLIGHT=16
 
-# Service-level defaults (all Weaviate traffic)
-GATEWAY_WEAVIATE_REQUESTS_PER_SECOND=50
-GATEWAY_WEAVIATE_MAX_CONCURRENCY=100
-
-# Per-provider overrides (#921): Spark LAN instance
-GATEWAY_WEAVIATE_SPARK_REQUESTS_PER_SECOND=100
-GATEWAY_WEAVIATE_SPARK_MAX_CONCURRENCY=50
-
-# Per-provider overrides (#921): Weaviate Cloud
-GATEWAY_WEAVIATE_CLOUD_REQUESTS_PER_SECOND=50
-GATEWAY_WEAVIATE_CLOUD_MAX_CONCURRENCY=25
-
-# Async client pool size (#922) - raise from default 10 for high-concurrency CLI
+# Async client pool size (#922) - max distinct Weaviate configs cached
 WEAVIATE_ASYNC_POOL_SIZE=20


### PR DESCRIPTION
## Summary

- Removes `GATEWAY_WEAVIATE_*` settings (gateway no longer routes Weaviate ops -- see pom-core#934)
- Adds `WEAVIATE_MAX_INFLIGHT=16` controlling the new factory-level semaphore
- Consolidates `WEAVIATE_ASYNC_POOL_SIZE=20` under a single WEAVIATE CONCURRENCY section

Companion to afctony64/pom-core#934 (fixes #930).

Made with [Cursor](https://cursor.com)