### PR TITLE
fix: handle non-dict entities in synthesis agent template

### DIFF
--- a/prompts/knowledge/chat_synthesis_agent.prompty
+++ b/prompts/knowledge/chat_synthesis_agent.prompty
@@ -140,7 +140,7 @@ user: |
   - **Intent**: {{ query_classification.get('intent', 'unknown') }}
   - **Confidence**: {{ query_classification.get('confidence', 0) }}
   {% if query_classification.get('entities') %}
-  - **Entities**: {% for e in query_classification.entities %}{{ e.value }} ({{ e.type }}){% if not loop.last %}, {% endif %}{% endfor %}
+  - **Entities**: {% for e in query_classification.entities %}{% if e is mapping %}{{ e.get('value', e.get('name', e)) }} ({{ e.get('type', 'entity') }}){% else %}{{ e }}{% endif %}{% if not loop.last %}, {% endif %}{% endfor %}
   {% endif %}
   {% if query_classification.get('reasoning') %}
   - **Analysis**: {{ query_classification.reasoning }}


### PR DESCRIPTION
Entities may be strings or dicts; use mapping check to render safely.

Made with [Cursor](https://cursor.com)