### PR TITLE
fix: productURL field falls back to company homepage instead of Not disclosed

### DIFF
--- a/schemas/Research_product_schema.yaml
+++ b/schemas/Research_product_schema.yaml
@@ -644,7 +644,7 @@ properties:
 - name: productURL
   dataType:
   - text[]
-  description: 'Primary website or landing page URL for {subject}. Find the product homepage, documentation site, or main marketing page. Example: https://www.example.com/product-name. Use "Not disclosed" if unknown.'
+  description: 'Primary website or landing page URL for {subject}. Find the product page, docs site, or marketing page. If no specific product page exists, use the parent company homepage (e.g. https://example.com). Always provide at least the company URL, never "Not disclosed".'
   parallel_to: products
   moduleConfig:
     text2vec-weaviate:


### PR DESCRIPTION
## Summary
- Updated `productURL` field description in `Research_product_schema.yaml` to instruct the LLM to always provide at least the parent company homepage URL when a specific product page can't be found
- Replaces `Use "Not disclosed" if unknown` with `Always provide at least the company URL, never "Not disclosed"`

## Test plan
- [x] Before: `productURL: 2/8 filled` (25%) — LLM returned "Not disclosed" for sub-products without dedicated pages
- [x] After: `productURL` no longer reported incomplete across 2 test runs (limit=1 and limit=2)
- [x] No regressions in other enrichment fields (7-8/8 filled per subject)

Made with [Cursor](https://cursor.com)