### PR TITLE
perf: tune CLI_MAX_CONCURRENT=50, document Weaviate backpressure

### DIFF
--- a/shared-config.env
+++ b/shared-config.env
@@ -443,8 +443,12 @@ STALE_RUN_CLEANUP_ENABLED=true
 # Overrides model card optimal_concurrency when set
 POMFLOW_MAX_CONCURRENT=20
 
-# Default max concurrent operations for standard pom-core CLIs
-CLI_MAX_CONCURRENT=100
+# Default max concurrent operations for standard pom-core CLIs.
+#   Relationship with WEAVIATE_MAX_INFLIGHT: at startup, all workers
+#   fire page_facts queries simultaneously. Burst = CLI_MAX_CONCURRENT × 5.
+#   At 50 × 5 = 250 queries through WEAVIATE_MAX_INFLIGHT=16 → ~16s drain.
+#   At 100 × 5 = 500 queries → 54s+ drain and LLM tool timeouts.
+CLI_MAX_CONCURRENT=50
 
 # =============================================================================
 # AI DIAGNOSTICS THRESHOLDS
@@ -569,8 +573,11 @@ CLOUDFLARE_TUNNEL_SPARK_ID=6d4a4972-ec26-4ca3-9df2-59b543b1e45a
 # rate limiter, so we must bound in-flight requests client-side.
 #
 # WEAVIATE_MAX_INFLIGHT: Max concurrent async operations per Weaviate instance.
-#   Default 16 is conservative. Tune via load testing (sweep 1, 2, 4, 8, 16, 32).
-#   Typical sweet spots: 8-16 for cloud, 16-32 for local Spark.
+#   Tested at 16, 32, 64 with 100 records (Feb 2026):
+#     16 → 230s, 17 errors | 32 → 240s, 26 errors | 64 → 256s, 61 errors
+#   Higher values saturate Weaviate and increase LLM tool timeouts.
+#   Relationship: startup_burst = CLI_MAX_CONCURRENT × 5 queries/record
+#   At 50×5=250 queries through 16 slots → ~16s drain (tolerable).
 WEAVIATE_MAX_INFLIGHT=16
 
 # Async client pool size (#922) - max distinct Weaviate configs cached


### PR DESCRIPTION
## Summary
- Reduce `CLI_MAX_CONCURRENT` from 100 to 50 to halve the Weaviate startup burst
- Add detailed comments documenting the relationship between `CLI_MAX_CONCURRENT` and `WEAVIATE_MAX_INFLIGHT`

## Evidence (100 records, industry researcher, prismatic tenant)

| Config | Wall time | Gateway errors | Max prep time |
|--------|-----------|---------------|---------------|
| MC=100, INF=16 | 230s | 17 timeouts | ~120s |
| MC=100, INF=32 | 240s | 26 timeouts | ~90s |
| MC=100, INF=64 | 256s | 61 timeouts | ~45s |
| **MC=50, INF=16** | **273s** | **0 timeouts** | **7s** |

Formula: `startup_burst = CLI_MAX_CONCURRENT × 5 queries/record` through `WEAVIATE_MAX_INFLIGHT` slots.  
At 50×5=250 queries through 16 slots → ~16s drain (tolerable).  
At 100×5=500 queries → 54s+ drain → LLM tool timeouts.

## Test plan
- [x] Ran 100 records at MC=50/INF=16 with zero errors
- [x] Verified result quality (enrichment completeness)
- [x] Comments cross-reference pom-core base.py documentation


Made with [Cursor](https://cursor.com)