### PR TITLE
fix: use ref_count_gt for reference field filters (fixes #975)

### DIFF
--- a/data_cards/entity_research_sfdc_linked_fullset.yaml
+++ b/data_cards/entity_research_sfdc_linked_fullset.yaml
@@ -37,15 +37,20 @@ parameters:
     - field: entityId
       operator: is_not_null
     - field: industry
-      operator: is_not_null
+      operator: ref_count_gt
+      value: 0
     - field: financial
-      operator: is_not_null
+      operator: ref_count_gt
+      value: 0
     - field: leadership
-      operator: is_not_null
+      operator: ref_count_gt
+      value: 0
     - field: customer
-      operator: is_not_null
+      operator: ref_count_gt
+      value: 0
     - field: product
-      operator: is_not_null
+      operator: ref_count_gt
+      value: 0
 
   relationship_traversal: true
   dynamic_templates: true


### PR DESCRIPTION
## Summary
- Replace `is_not_null` (Python post-filter) with `ref_count_gt: 0` (native Weaviate server-side filter) for the 5 researcher reference fields in `entity_research_sfdc_linked_fullset` data card
- This pushes filtering to Weaviate, avoiding fetching ~7000 unnecessary records over gRPC

## Test plan
- [x] YAML validation passed
- [x] `ref_count_gt` operator already supported in pom-core PropertyFilter.to_weaviate_filter()


Made with [Cursor](https://cursor.com)