### PR TITLE
fix(schema): add Domain materialized depth fields

### DIFF
--- a/schemas/domain_schema.yaml
+++ b/schemas/domain_schema.yaml
@@ -1019,6 +1019,45 @@ properties:
   - processing
 
 # ============================================================================
+# MATERIALIZED RELATIONSHIP DEPTH (computed by materialize_depth_cli)
+# depth=1 means source (spawnedBy is null/empty)
+# depth=2..5 means N-1 hops from a source via typed relationship refs
+# depth=0 means processed but unreachable under homogeneous traversal rules
+# ============================================================================
+- name: competitor_depth
+  dataType:
+  - int
+  description: Materialized competitor depth. 0=unreachable(processed), 1=source, 2-5=hops from source.
+  indexFilterable: true
+  sets:
+  - system
+  tags:
+  - relationship
+  - materialized
+
+- name: customer_depth
+  dataType:
+  - int
+  description: Materialized customer depth. 0=unreachable(processed), 1=source, 2-5=hops from source.
+  indexFilterable: true
+  sets:
+  - system
+  tags:
+  - relationship
+  - materialized
+
+- name: partner_depth
+  dataType:
+  - int
+  description: Materialized partner depth. 0=unreachable(processed), 1=source, 2-5=hops from source.
+  indexFilterable: true
+  sets:
+  - system
+  tags:
+  - relationship
+  - materialized
+
+# ============================================================================
 # PROCESSING FLAGS - SYSTEM FIELDS (pipeline-managed, except domain_research)
 # ============================================================================
 - name: domain_enriched


### PR DESCRIPTION
## Summary
- Add `competitor_depth`, `customer_depth`, `partner_depth` to the Domain schema.
- Unblocks `materialize_depth_cli` from persisting depth values (SchemaCoercer was dropping the fields).

## Evidence
- CLI logs repeatedly showed: `SchemaCoercer [Domain]: DROPPED ... ['competitor_depth']`.
- Container-mounted shared schema `/app/shared_config/schemas/domain_schema.yaml` did not include these fields.

## Notes
- Semantics documented in schema comments.
- Uses `0` for processed-but-unreachable (to distinguish from missing/unprocessed).

Fixes #176.

Made with [Cursor](https://cursor.com)