### PR TITLE
feat: add sales prospecting workspace UX configs

### DIFF
--- a/ux_configs/workspaces/hydration/sales_prospecting_hydration_policy.prompty
+++ b/ux_configs/workspaces/hydration/sales_prospecting_hydration_policy.prompty
@@ -105,4 +105,3 @@ This policy is designed to support a fast SDR workflow:
 - Hydration is best-effort and retrieve-only.
 - Hydration must never run without a resolved primary domain.
 - Personal memory can influence planning, but must not be stored into ecosystem caches.
-

--- a/ux_configs/workspaces/skills/sales_prospecting_workspace_skill_profile.prompty
+++ b/ux_configs/workspaces/skills/sales_prospecting_workspace_skill_profile.prompty
@@ -86,4 +86,3 @@ This file defines the default behavior for an SDR/prospecting workspace.
 - The router intent strings come from `prompts/knowledge/chat_query_router.prompty`.
 - Any learned preferences should be stored in workspace/user memory, not persisted
   back into this file.
-


### PR DESCRIPTION
## Summary
- Add initial workspace UX configs for sales prospecting:
  - Workspace skill profile (`workspaces.skills`)
  - Hydration policy (`workspaces.hydration`)

## Test plan
- [ ] `python scripts/validate_all_configs.py` (optional)


Made with [Cursor](https://cursor.com)